### PR TITLE
Feat: 카카오 로그인 머지 요청

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ out/
 .vscode/
 
 # Spring 설정
+.env
 application.yml
 application-*.yml
 application-*.properties

--- a/src/main/java/com/project/cozystay/CozystayApplication.java
+++ b/src/main/java/com/project/cozystay/CozystayApplication.java
@@ -2,7 +2,9 @@ package com.project.cozystay;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CozystayApplication {
 

--- a/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
@@ -1,0 +1,100 @@
+package com.project.cozystay.auth;
+
+import com.project.cozystay.user.domain.Role;
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        // 1. (스프링이 알아서 처리한) 카카오 사용자 정보를 가져옵니다.
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        // 2. 카카오가 준 원본 JSON 데이터를 Map으로 가져옵니다.
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // ⭐️ 카카오 토큰 정보 가져오기 (DB에 저장하기 위해)
+        OAuth2AccessToken accessToken = userRequest.getAccessToken();
+        String kakaoAccessToken = accessToken.getTokenValue();
+        Instant expiresAtInstant = accessToken.getExpiresAt();
+        LocalDateTime kakaoTokenExpiresAt = (expiresAtInstant != null) ?
+                LocalDateTime.ofInstant(expiresAtInstant, ZoneId.systemDefault()) : null;
+
+        // (참고: RefreshToken은 기본 설정으론 안 올 수도 있습니다. null일 수 있음)
+        String kakaoRefreshToken = null;
+
+        // 3. ✨ 7단계: 회원 조회 또는 신규 가입 (핵심 로직)
+        User user = saveOrUpdate(attributes, kakaoAccessToken, kakaoRefreshToken, kakaoTokenExpiresAt);
+
+        // 4. 시큐리티가 이 사용자를 인식할 수 있도록 포장합니다. (3번 핸들러로 전달됨)
+        //    "nameAttributeKey"를 "id"로 설정해야 3번 핸들러에서 "id"로 꺼낼 수 있습니다.
+        return new DefaultOAuth2User(
+                Collections.singleton(user.getUserRole()),
+                attributes,
+                "id" // 카카오의 고유 ID 필드명 (yml의 user-name-attribute와 일치)
+        );
+    }
+
+    // 7단계(회원 조회/가입)를 처리하는 메서드
+    private User saveOrUpdate(Map<String, Object> attributes,
+                              String kakaoAccessToken, String kakaoRefreshToken, LocalDateTime kakaoTokenExpiresAt) {
+
+        // 카카오가 준 고유 ID
+        Long kakaoId = (Long) attributes.get("id");
+
+        // 카카오 계정 정보 파싱 (카카오 응답 스펙 기준)
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        String email = (String) kakaoAccount.get("email");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        String nickname = (String) profile.get("nickname");
+
+        String profileImageUrl = (String) profile.get("profile_image_url");
+
+        // DB 조회
+        Optional<User> userOptional = userRepository.findByKakaoId(kakaoId);
+
+        User user;
+        if (userOptional.isPresent()) {
+            // [기존 회원]
+            user = userOptional.get();
+            user = user.updateNicknameAndProfile(nickname, profileImageUrl) // 예시
+                    .updateKakaoTokens(kakaoAccessToken, kakaoTokenExpiresAt);
+            userRepository.save(user);
+        } else {
+            // [신규 회원]
+            user = User.builder()
+                    .kakaoId(kakaoId)
+                    .email(email)
+                    .nickName(nickname)
+                    .profileImageUrl(profileImageUrl)
+                    .kakaoAccessToken(kakaoAccessToken)
+                    .tokenExpiresAt(kakaoTokenExpiresAt)
+                    .userRole(Role.USER)
+                    .build();
+            userRepository.save(user);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
@@ -30,41 +30,31 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
-        // 1. (스프링이 알아서 처리한) 카카오 사용자 정보를 가져옵니다.
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        // 2. 카카오가 준 원본 JSON 데이터를 Map으로 가져옵니다.
         Map<String, Object> attributes = oAuth2User.getAttributes();
 
-        // ⭐️ 카카오 토큰 정보 가져오기 (DB에 저장하기 위해)
         OAuth2AccessToken accessToken = userRequest.getAccessToken();
         String kakaoAccessToken = accessToken.getTokenValue();
         Instant expiresAtInstant = accessToken.getExpiresAt();
         LocalDateTime kakaoTokenExpiresAt = (expiresAtInstant != null) ?
                 LocalDateTime.ofInstant(expiresAtInstant, ZoneId.systemDefault()) : null;
 
-        // (참고: RefreshToken은 기본 설정으론 안 올 수도 있습니다. null일 수 있음)
         String kakaoRefreshToken = null;
 
-        // 3. ✨ 7단계: 회원 조회 또는 신규 가입 (핵심 로직)
         User user = saveOrUpdate(attributes, kakaoAccessToken, kakaoRefreshToken, kakaoTokenExpiresAt);
 
-        // 4. 시큐리티가 이 사용자를 인식할 수 있도록 포장합니다. (3번 핸들러로 전달됨)
-        //    "nameAttributeKey"를 "id"로 설정해야 3번 핸들러에서 "id"로 꺼낼 수 있습니다.
         return new DefaultOAuth2User(
                 Collections.singleton(user.getUserRole()),
                 attributes,
-                "id" // 카카오의 고유 ID 필드명 (yml의 user-name-attribute와 일치)
+                "id"
         );
     }
 
-    // 7단계(회원 조회/가입)를 처리하는 메서드
     private User saveOrUpdate(Map<String, Object> attributes,
                               String kakaoAccessToken, String kakaoRefreshToken, LocalDateTime kakaoTokenExpiresAt) {
 
-        // 카카오가 준 고유 ID
         Long kakaoId = (Long) attributes.get("id");
 
-        // 카카오 계정 정보 파싱 (카카오 응답 스펙 기준)
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         String email = (String) kakaoAccount.get("email");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
@@ -72,7 +62,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String profileImageUrl = (String) profile.get("profile_image_url");
 
-        // DB 조회
         Optional<User> userOptional = userRepository.findByKakaoId(kakaoId);
 
         User user;

--- a/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
@@ -80,6 +80,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         Optional<User> userOptional = userRepository.findByKakaoId(kakaoId);
 
         User user;
+        // TODO: JPA 더티 체킹 활용
         if (userOptional.isPresent()) {
             // [기존 회원]
             user = userOptional.get();

--- a/src/main/java/com/project/cozystay/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/cozystay/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,115 @@
+package com.project.cozystay.auth;
+
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository; // 🚨 토큰에서 ID 꺼낸 후 DB에서 실제 유저 조회
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        // ⭐️ "startsWith" 대신 "equals" 또는 "antMatcher"를 사용해야 합니다.
+        // ⭐️ 이 목록은 SecurityConfig의 permitAll()과 "정확히" 일치해야 합니다.
+        List<String> excludePath = List.of(
+                "/",
+                "/auth/success",
+                "/login" // /login?error 등도 처리
+        );
+
+        String path = request.getRequestURI();
+
+        // ⭐️ 정확히 일치하는 경로(excludePath)가 있으면 true (필터링 안 함)
+        if (excludePath.contains(path)) {
+            return true;
+        }
+
+        // ⭐️ /swagger-ui, /v3/api-docs, /h2-console 등 "하위 경로"를 모두 열어야 할 때
+        if (path.startsWith("/swagger-ui") ||
+                path.startsWith("/v3/api-docs") ||
+                path.startsWith("/h2-console") ||
+                path.startsWith("/login/oauth2")) { // /login/oauth2/code/kakao
+            return true;
+        }
+
+        return false; // 그 외 모든 경로는 필터링 함
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        // 1. 요청 헤더에서 "Authorization" 헤더를 찾습니다.
+        String token = resolveToken(request);
+
+        // 2. 토큰이 존재하고, 유효한 토큰인지 검사합니다. (JwtProvider 활용)
+        if (StringUtils.hasText(token) && jwtProvider.validateToken(token)) {
+            try {
+                // 3. 토큰에서 사용자 ID (우리 DB의 PK)를 꺼냅니다.
+                Long userId = jwtProvider.getUserId(token);
+
+                // 4. 🚨 DB에서 실제 사용자를 조회합니다. (토큰이 위조되지 않았어도, 탈퇴한 회원일 수 있으므로)
+                User user = userRepository.findById(userId)
+                        .orElseThrow(() -> new RuntimeException("해당 ID의 회원을 찾을 수 없습니다.")); // TODO: 커스텀 예외
+
+                // 5. ✨ 스프링 시큐리티 컨텍스트에 "인증된 사용자" 정보를 등록합니다.
+                //    이게 있어야 @AuthenticationPrincipal 같은 어노테이션이 동작하고,
+                //    Controller에서 "누가" 요청했는지 알 수 있습니다.
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        user, // Principal (인증된 주체, 여기서는 User 객체 자체를 넣음)
+                        null, // Credentials (자격 증명, JWT 방식에선 불필요)
+                        Collections.singleton(new SimpleGrantedAuthority(user.getUserRole().getKey())) // 권한
+                );
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", user.getId(), request.getRequestURI());
+
+            } catch (Exception e) {
+                log.warn("토큰에서 인증 정보를 가져오는 데 실패했습니다.", e);
+                // (선택) 여기서 response.sendError()로 401 응답을 즉시 보낼 수도 있습니다.
+            }
+        } else {
+            // 토큰이 없거나 유효하지 않지만, 로그인이 필요 없는 페이지(permitAll)일 수 있으므로 일단 통과
+            log.trace("유효한 JWT 토큰이 없습니다, uri: {}", request.getRequestURI());
+        }
+
+        // 6. 다음 필터로 요청을 넘깁니다.
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Request Header에서 "Authorization" 토큰을 꺼내는 헬퍼 메서드
+     * "Bearer [토큰값]" 형태여야 합니다.
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7); // "Bearer " 7글자 뒤부터가 실제 토큰
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/project/cozystay/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/cozystay/auth/JwtAuthenticationFilter.java
@@ -70,7 +70,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long userId = jwtProvider.getUserId(token);
 
                 User user = userRepository.findById(userId)
-                        .orElseThrow(() -> new RuntimeException("해당 ID의 회원을 찾을 수 없습니다.")); // TODO: 커스텀 예외
+                        // TODO: 커스텀 예외
+                        .orElseThrow(() -> new RuntimeException("해당 ID의 회원을 찾을 수 없습니다."));
 
                 Authentication authentication = new UsernamePasswordAuthenticationToken(
                         user, // Principal (인증된 주체, 여기서는 User 객체 자체를 넣음)
@@ -81,10 +82,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", user.getId(), request.getRequestURI());
 
+            } catch (io.jsonwebtoken.ExpiredJwtException e) {
+                log.warn("만료된 JWT 토큰입니다. token={}, message={}", token, e.getMessage());
+            } catch (io.jsonwebtoken.MalformedJwtException e) {
+                log.warn("형식이 잘못된 JWT 토큰입니다. token={}, message={}", token, e.getMessage());
+            } catch (io.jsonwebtoken.JwtException e) {
+                log.warn("JWT 관련 예외가 발생했습니다. token={}, message={}", token, e.getMessage());
             } catch (Exception e) {
                 log.warn("토큰에서 인증 정보를 가져오는 데 실패했습니다.", e);
             }
-        } else {
+        }
+        else {
             log.trace("유효한 JWT 토큰이 없습니다, uri: {}", request.getRequestURI());
         }
 

--- a/src/main/java/com/project/cozystay/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/cozystay/auth/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        // 이 목록은 SecurityConfig의 permitAll()과 일치.
+
         List<String> excludePath = List.of(
                 "/",
                 "/auth/success",
@@ -40,16 +40,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String path = request.getRequestURI();
 
-        // 정확히 일치하는 경로가 있으면 필터링 안 함
         if (excludePath.contains(path)) {
             return true;
         }
 
-        // /swagger-ui, /v3/api-docs, /h2-console 등 하위 경로를 모두 열어야 할 때
         if (path.startsWith("/swagger-ui") ||
                 path.startsWith("/v3/api-docs") ||
                 path.startsWith("/h2-console") ||
-                path.startsWith("/login/oauth2")) { // /login/oauth2/code/kakao
+                path.startsWith("/login/oauth2") ||
+                path.startsWith("/oauth2/authorization")) {
             return true;
         }
 

--- a/src/main/java/com/project/cozystay/auth/JwtProvider.java
+++ b/src/main/java/com/project/cozystay/auth/JwtProvider.java
@@ -1,0 +1,104 @@
+package com.project.cozystay.auth;
+
+import com.project.cozystay.user.domain.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretString;
+
+    @Value("${jwt.expiration}") // 액세스 토큰 만료 시간 (초)
+    private Long accessTokenExpirationSeconds;
+
+    // (선택) 리프레시 토큰 만료 시간 (예: 7일)
+    private final Long REFRESH_TOKEN_EXPIRATION_SECONDS = 60L * 60 * 24 * 7;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    protected void init() {
+        // yml의 secretString을 SecretKey 객체로 변환
+        this.secretKey = Keys.hmacShaKeyFor(secretString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * 8단계: Access Token (입장권) 생성
+     */
+    public String createAccessToken(Long userId, Role role) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessTokenExpirationSeconds * 1000); // 밀리초 단위
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId)) // 토큰의 주체(subject) = 우리 DB 유저 ID
+                .claim("role", role.getKey())    // "role"이라는 이름으로 권한 정보 추가
+                .issuedAt(now)                   // 발급 시간
+                .expiration(validity)            // 만료 시간
+                .signWith(secretKey)             // 비밀키로 서명
+                .compact();
+    }
+
+    /**
+     * 8단계: Refresh Token (재발급권) 생성
+     */
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_SECONDS * 1000);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId)) // Access Token과 마찬가지로 유저 ID
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // --- (다음 단계) JWT 필터에서 사용할 메서드들 ---
+
+    /**
+     * 토큰에서 Claims(정보) 추출
+     */
+    public Claims getClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (Exception e) {
+            log.warn("유효하지 않은 토큰입니다. {}", e.getMessage());
+            throw new IllegalArgumentException("Invalid token", e); // 예외 처리 필요
+        }
+    }
+
+    /**
+     * 토큰 유효성 검사
+     */
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = getClaims(token);
+            return !claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * 토큰에서 사용자 ID(Long) 추출
+     */
+    public Long getUserId(String token) {
+        return Long.parseLong(getClaims(token).getSubject());
+    }
+}

--- a/src/main/java/com/project/cozystay/auth/JwtProvider.java
+++ b/src/main/java/com/project/cozystay/auth/JwtProvider.java
@@ -23,14 +23,12 @@ public class JwtProvider {
     @Value("${jwt.expiration}") // 액세스 토큰 만료 시간 (초)
     private Long accessTokenExpirationSeconds;
 
-    // (선택) 리프레시 토큰 만료 시간 (예: 7일)
     private final Long REFRESH_TOKEN_EXPIRATION_SECONDS = 60L * 60 * 24 * 7;
 
     private SecretKey secretKey;
 
     @PostConstruct
     protected void init() {
-        // yml의 secretString을 SecretKey 객체로 변환
         this.secretKey = Keys.hmacShaKeyFor(secretString.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -58,14 +56,13 @@ public class JwtProvider {
         Date validity = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_SECONDS * 1000);
 
         return Jwts.builder()
-                .subject(String.valueOf(userId)) // Access Token과 마찬가지로 유저 ID
+                .subject(String.valueOf(userId))
                 .issuedAt(now)
                 .expiration(validity)
                 .signWith(secretKey)
                 .compact();
     }
 
-    // --- (다음 단계) JWT 필터에서 사용할 메서드들 ---
 
     /**
      * 토큰에서 Claims(정보) 추출

--- a/src/main/java/com/project/cozystay/auth/JwtProvider.java
+++ b/src/main/java/com/project/cozystay/auth/JwtProvider.java
@@ -74,6 +74,9 @@ public class JwtProvider {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다: {}", e.getMessage());
+            throw e; // 그대로 던져서 필터/컨트롤러에서 "만료"라고 구분해서 처리
         } catch (Exception e) {
             log.warn("유효하지 않은 토큰입니다. {}", e.getMessage());
             throw new IllegalArgumentException("Invalid token", e); // 예외 처리 필요

--- a/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
@@ -43,6 +43,9 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String refreshToken = jwtProvider.createRefreshToken(user.getId());
         // TODO: refreshToken은 DB나 Redis에 저장하는 로직 추가
 
+        // TODO: URL에 JWT 토큰 넘기는 방식 변경
+        // TODO: 같은 도메인이라면 HttpOnly 쿠키 사용
+        // TODO: 다른 도메인이라면 짧은 인증 코드(UUID) 방식
         String targetUrl = UriComponentsBuilder.fromUriString(frontendUrl + "/auth/success") // 프론트의 콜백 페이지
                 .queryParam("accessToken", accessToken)
                 .queryParam("refreshToken", refreshToken)

--- a/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,61 @@
+package com.project.cozystay.auth;
+
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.repository.UserRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler{
+
+    private final JwtProvider jwtProvider; // (다음 단계) 우리가 만들 JWT 발급 유틸
+    private final UserRepository userRepository; // user/ 패키지의 리포지토리
+
+    // application.yml 에 설정한 프론트엔드 URL
+    @Value("${redirect.frontend-url}")
+    private String frontendUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        // 1. 2번 서비스에서 포장했던 OAuth2User 객체를 가져옵니다.
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        // 2. 2번 서비스에서 "nameAttributeKey"로 지정했던 "id" (카카오 고유 ID)를 꺼냅니다.
+        Long kakaoId = oAuth2User.getAttribute("id");
+
+        log.info("카카오 로그인 성공. Kakao ID: {}", kakaoId);
+
+        // 3. DB에서 이 카카오 ID를 가진 우리 회원을 찾습니다.
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. Kakao ID: " + kakaoId));
+
+        // 4. ✨ 8단계! 우리 CozyStay의 JWT(액세스 토큰)를 발급합니다.
+        //    JWT에는 카카오 ID가 아닌, 우리 DB의 PK (user.getId())를 담습니다.
+        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
+        String refreshToken = jwtProvider.createRefreshToken(user.getId());
+        // TODO: refreshToken은 DB나 Redis에 저장하는 로직 추가
+
+        // 5. 프론트엔드로 JWT를 실어서 리다이렉트!
+        String targetUrl = UriComponentsBuilder.fromUriString(frontendUrl + "/auth/success") // 프론트의 콜백 페이지
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+
+        log.info("JWT 발급 완료. 프론트엔드로 리다이렉트: {}", targetUrl);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
@@ -21,35 +21,28 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler{
 
-    private final JwtProvider jwtProvider; // (다음 단계) 우리가 만들 JWT 발급 유틸
-    private final UserRepository userRepository; // user/ 패키지의 리포지토리
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
-    // application.yml 에 설정한 프론트엔드 URL
     @Value("${redirect.frontend-url}")
     private String frontendUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
 
-        // 1. 2번 서비스에서 포장했던 OAuth2User 객체를 가져옵니다.
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-        // 2. 2번 서비스에서 "nameAttributeKey"로 지정했던 "id" (카카오 고유 ID)를 꺼냅니다.
         Long kakaoId = oAuth2User.getAttribute("id");
 
         log.info("카카오 로그인 성공. Kakao ID: {}", kakaoId);
 
-        // 3. DB에서 이 카카오 ID를 가진 우리 회원을 찾습니다.
         User user = userRepository.findByKakaoId(kakaoId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. Kakao ID: " + kakaoId));
 
-        // 4. ✨ 8단계! 우리 CozyStay의 JWT(액세스 토큰)를 발급합니다.
-        //    JWT에는 카카오 ID가 아닌, 우리 DB의 PK (user.getId())를 담습니다.
         String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());
         // TODO: refreshToken은 DB나 Redis에 저장하는 로직 추가
 
-        // 5. 프론트엔드로 JWT를 실어서 리다이렉트!
         String targetUrl = UriComponentsBuilder.fromUriString(frontendUrl + "/auth/success") // 프론트의 콜백 페이지
                 .queryParam("accessToken", accessToken)
                 .queryParam("refreshToken", refreshToken)

--- a/src/main/java/com/project/cozystay/common/BaseTimeEntity.java
+++ b/src/main/java/com/project/cozystay/common/BaseTimeEntity.java
@@ -15,10 +15,10 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
-    @CreatedDate // ⭐️ 생성 시 시간 자동 저장
+    @CreatedDate // 생성 시 시간 자동 저장
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @LastModifiedDate // ⭐️ 수정 시 시간 자동 저장
+    @LastModifiedDate // 수정 시 시간 자동 저장
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/project/cozystay/common/BaseTimeEntity.java
+++ b/src/main/java/com/project/cozystay/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.project.cozystay.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate // ⭐️ 생성 시 시간 자동 저장
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate // ⭐️ 수정 시 시간 자동 저장
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/project/cozystay/config/SecurityConfig.java
+++ b/src/main/java/com/project/cozystay/config/SecurityConfig.java
@@ -1,0 +1,68 @@
+package com.project.cozystay.config;
+
+import com.project.cozystay.auth.CustomOAuth2UserService;
+import com.project.cozystay.auth.JwtAuthenticationFilter;
+import com.project.cozystay.auth.OAuth2LoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                // 1. JWT 방식이므로 세션 STATELESS, CSRF/FormLogin/HttpBasic 비활성화
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+
+                // 2. URL별 권한 설정 (이게 바로 카카오 창이 안 뜨게 하는 부분)
+                .authorizeHttpRequests(authz -> authz
+                        // Swagger UI, H2 콘솔 등 개발 편의 기능 모두 허용
+                        .requestMatchers("/swagger-ui.html", "/v3/api-docs/**", "/h2-console/**").permitAll()
+
+                        // ⭐️ "/" (정문), "/api/auth/**", "/login/oauth2/**" (로그인 관련 경로)는 모두 허용
+                        .requestMatchers("/", "/auth/success", "/login/**", "/oauth2/**").permitAll()
+
+                        // 그 외 모든 요청은 인증 필요
+                        .anyRequest().authenticated()
+                )
+
+                // 3. ✨ OAuth2 로그인 설정 ✨
+                .oauth2Login(oauth2 -> oauth2
+
+                        // .../oauth2/authorization/{...}로 오는 요청들 처리
+                        .authorizationEndpoint(ep -> ep
+                                .authorizationRequestRepository(
+                                        new HttpSessionOAuth2AuthorizationRequestRepository()
+                                )
+                        )
+                        // (중요) 카카오가 정보 줬을 때(7단계) 실행할 서비스 등록
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                        // (중요) 로그인 최종 성공 시(8단계) 실행할 핸들러 등록
+                        .successHandler(oAuth2LoginSuccessHandler)
+                );
+
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/project/cozystay/config/SecurityConfig.java
+++ b/src/main/java/com/project/cozystay/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
 
-                // 2. URL별 권한 설정 (이게 바로 카카오 창이 안 뜨게 하는 부분)
+                // 2. URL별 권한 설정
                 .authorizeHttpRequests(authz -> authz
                         // Swagger UI, H2 콘솔 등 개발 편의 기능 모두 허용
                         .requestMatchers("/swagger-ui.html", "/v3/api-docs/**", "/h2-console/**").permitAll()
@@ -44,7 +44,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
 
-                // 3. ✨ OAuth2 로그인 설정 ✨
+                // 3. OAuth2 로그인 설정
                 .oauth2Login(oauth2 -> oauth2
 
                         // .../oauth2/authorization/{...}로 오는 요청들 처리
@@ -53,11 +53,9 @@ public class SecurityConfig {
                                         new HttpSessionOAuth2AuthorizationRequestRepository()
                                 )
                         )
-                        // (중요) 카카오가 정보 줬을 때(7단계) 실행할 서비스 등록
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )
-                        // (중요) 로그인 최종 성공 시(8단계) 실행할 핸들러 등록
                         .successHandler(oAuth2LoginSuccessHandler)
                 );
 

--- a/src/main/java/com/project/cozystay/config/SecurityConfig.java
+++ b/src/main/java/com/project/cozystay/config/SecurityConfig.java
@@ -37,8 +37,8 @@ public class SecurityConfig {
                         // Swagger UI, H2 콘솔 등 개발 편의 기능 모두 허용
                         .requestMatchers("/swagger-ui.html", "/v3/api-docs/**", "/h2-console/**").permitAll()
 
-                        // ⭐️ "/" (정문), "/api/auth/**", "/login/oauth2/**" (로그인 관련 경로)는 모두 허용
-                        .requestMatchers("/", "/auth/success", "/login/**", "/oauth2/**").permitAll()
+                        // "/", "/api/auth/**", "/login/oauth2/**" (로그인 관련 경로)는 모두 허용
+                        .requestMatchers("/", "/auth/success", "/login/**", "/oauth2/**", "/api/auth/**").permitAll()
 
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/project/cozystay/user/domain/Role.java
+++ b/src/main/java/com/project/cozystay/user/domain/Role.java
@@ -1,0 +1,22 @@
+package com.project.cozystay.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role implements GrantedAuthority {
+
+    USER("ROLE_USER", "일반 사용자"),
+    HOST("ROLE_HOST", "호스트"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String title;
+
+    @Override
+    public String getAuthority() {
+        return key;
+    }
+}

--- a/src/main/java/com/project/cozystay/user/domain/User.java
+++ b/src/main/java/com/project/cozystay/user/domain/User.java
@@ -1,0 +1,51 @@
+package com.project.cozystay.user.domain;
+
+import com.project.cozystay.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String email;
+
+    @Column(nullable = false)
+    private String nickName;
+
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role userRole;
+
+    @Column(unique = true, nullable = false)
+    private Long kakaoId;
+
+    private String kakaoAccessToken;
+
+    private LocalDateTime tokenExpiresAt;
+
+
+    public User updateNicknameAndProfile(String nickName, String profileImageUrl) {
+        this.nickName = nickName;
+        this.profileImageUrl = profileImageUrl;
+        return this;
+    }
+
+    public User updateKakaoTokens(String accessToken, LocalDateTime expiresAt) {
+        this.kakaoAccessToken = accessToken;
+        this.tokenExpiresAt = expiresAt;
+        return this;
+    }
+}

--- a/src/main/java/com/project/cozystay/user/repository/UserRepository.java
+++ b/src/main/java/com/project/cozystay/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.project.cozystay.user.repository;
+
+import com.project.cozystay.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    // 카카오 ID로 회원 조회
+    Optional<User> findByKakaoId(Long kakaoId);
+}


### PR DESCRIPTION
## 🔗 반영 브랜치

(#1 ) feature/login -> develop

## 📝 작업 내용
<img width="1285" height="228" alt="image" src="https://github.com/user-attachments/assets/493677cf-ab71-473d-9c01-ea629eea544c" />

- 카카오 로그인 구현
- DB에 User 정보 저장
  - 리프래시 토큰, 휴대폰 번호는 미저장

## 💬 리뷰 요구사항
- 재발급 로직은 이후에 구현 후 따로 PR 올릴 예정
