### PR TITLE
Feat: 사용자 CRUD 구현 및 머지 요청

### DIFF
--- a/src/main/java/com/project/cozystay/auth/CustomOAuth2User.java
+++ b/src/main/java/com/project/cozystay/auth/CustomOAuth2User.java
@@ -40,6 +40,6 @@ public class CustomOAuth2User implements OAuth2User {
     @Override
     public String getName() {
         // Security가 내부에서 사용하는 "이름"
-        return user.getKakaoId().toString();
+        return user.getProviderId();
     }
 }

--- a/src/main/java/com/project/cozystay/auth/CustomOAuth2User.java
+++ b/src/main/java/com/project/cozystay/auth/CustomOAuth2User.java
@@ -1,6 +1,7 @@
 package com.project.cozystay.auth;
 
 import com.project.cozystay.user.domain.User;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -9,6 +10,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+@Getter
 public class CustomOAuth2User implements OAuth2User {
 
     private final User user;
@@ -23,9 +25,6 @@ public class CustomOAuth2User implements OAuth2User {
         return user.getId();
     }
 
-    public String getEmail() {
-        return user.getEmail();
-    }
 
     @Override
     public Map<String, Object> getAttributes() {

--- a/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
@@ -49,7 +49,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private User saveOrUpdate(Map<String, Object> attributes,
                               String kakaoAccessToken, String kakaoRefreshToken, LocalDateTime kakaoTokenExpiresAt) {
 
-        Long kakaoId = (Long) attributes.get("id");
+        Long providerId = (Long) attributes.get("id");
 
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         if (kakaoAccount == null) {
@@ -73,7 +73,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException("카카오에서 필수 사용자 정보(email 또는 nickname)를 제공하지 않았습니다.");
         }
 
-        Optional<User> userOptional = userRepository.findByKakaoId(kakaoId);
+        Optional<User> userOptional = userRepository.findByProviderId(providerId.toString());
 
         User user;
         // TODO: JPA 더티 체킹 활용
@@ -81,16 +81,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             // [기존 회원]
             user = userOptional.get();
             user = user.updateNicknameAndProfile(nickname, profileImageUrl)
-                    .updateKakaoTokens(kakaoAccessToken, kakaoTokenExpiresAt);
+                    .updateOauthTokens(kakaoAccessToken, kakaoTokenExpiresAt);
             userRepository.save(user);
         } else {
             // [신규 회원]
             user = User.builder()
-                    .kakaoId(kakaoId)
+                    .providerId(providerId.toString())
                     .email(email)
                     .nickName(nickname)
                     .profileImageUrl(profileImageUrl)
-                    .kakaoAccessToken(kakaoAccessToken)
+                    .oauthAccessToken(kakaoAccessToken)
                     .tokenExpiresAt(kakaoTokenExpiresAt)
                     .userRole(Role.USER)
                     .build();

--- a/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
@@ -1,7 +1,9 @@
 package com.project.cozystay.auth;
 
+import com.project.cozystay.user.domain.AuthProvider;
 import com.project.cozystay.user.domain.Role;
 import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.domain.UserGrade;
 import com.project.cozystay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -34,20 +36,41 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         Map<String, Object> attributes = oAuth2User.getAttributes();
 
         OAuth2AccessToken accessToken = userRequest.getAccessToken();
-        String kakaoAccessToken = accessToken.getTokenValue();
+        String oauthAccessToken = accessToken.getTokenValue();
         Instant expiresAtInstant = accessToken.getExpiresAt();
-        LocalDateTime kakaoTokenExpiresAt = (expiresAtInstant != null) ?
+        LocalDateTime tokenExpiresAt = (expiresAtInstant != null) ?
                 LocalDateTime.ofInstant(expiresAtInstant, ZoneId.systemDefault()) : null;
 
-        String kakaoRefreshToken = null;
+        //String oauthRefreshToken = null;
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        AuthProvider provider = convertToProvider(registrationId);
 
-        User user = saveOrUpdate(attributes, kakaoAccessToken, kakaoRefreshToken, kakaoTokenExpiresAt);
+        User user = saveOrUpdate(attributes, oauthAccessToken, tokenExpiresAt, provider);
+
 
         return new CustomOAuth2User(user, attributes);
     }
 
+    private AuthProvider convertToProvider(String registrationId) {
+
+        // 휴대폰 번호 패턴이면 LOCAL
+        if (registrationId != null && registrationId.matches("^01[0-9]{8,9}$")) {
+            return AuthProvider.LOCAL;
+        }
+
+        // 그 외는 소셜 로그인
+        return switch (registrationId.toLowerCase()) {
+            case "kakao" -> AuthProvider.KAKAO;
+            case "naver" -> AuthProvider.NAVER;
+            case "google" -> AuthProvider.GOOGLE;
+            default -> throw new IllegalArgumentException("지원하지 않는 provider: " + registrationId);
+        };
+    }
+
     private User saveOrUpdate(Map<String, Object> attributes,
-                              String kakaoAccessToken, String kakaoRefreshToken, LocalDateTime kakaoTokenExpiresAt) {
+                              String oauthAccessToken,
+                              LocalDateTime kakaoTokenExpiresAt,
+                              AuthProvider provider) {
 
         Long providerId = (Long) attributes.get("id");
 
@@ -78,21 +101,25 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         User user;
         // TODO: JPA 더티 체킹 활용
         if (userOptional.isPresent()) {
-            // [기존 회원]
+            // 기존 회원
             user = userOptional.get();
             user = user.updateNicknameAndProfile(nickname, profileImageUrl)
-                    .updateOauthTokens(kakaoAccessToken, kakaoTokenExpiresAt);
-            userRepository.save(user);
+                    .updateOauthTokens(oauthAccessToken, kakaoTokenExpiresAt);
         } else {
-            // [신규 회원]
+            // 신규 회원
             user = User.builder()
-                    .providerId(providerId.toString())
-                    .email(email)
                     .nickName(nickname)
+                    .email(email)
                     .profileImageUrl(profileImageUrl)
-                    .oauthAccessToken(kakaoAccessToken)
-                    .tokenExpiresAt(kakaoTokenExpiresAt)
+                    .provider(provider)
+                    .providerId(providerId.toString())
                     .userRole(Role.USER)
+                    .userGrade(UserGrade.BRONZE)
+                    .totalCompletedBookings(0)
+                    .totalStayedNights(0)
+                    .reviewCount(0)
+                    .oauthAccessToken(oauthAccessToken)
+                    .tokenExpiresAt(kakaoTokenExpiresAt)
                     .build();
             userRepository.save(user);
         }

--- a/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/cozystay/auth/CustomOAuth2UserService.java
@@ -96,7 +96,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException("카카오에서 필수 사용자 정보(email 또는 nickname)를 제공하지 않았습니다.");
         }
 
-        Optional<User> userOptional = userRepository.findByProviderId(providerId.toString());
+        Optional<User> userOptional = userRepository.findByProviderIdAndProvider(providerId.toString(), provider);
 
         User user;
         // TODO: JPA 더티 체킹 활용

--- a/src/main/java/com/project/cozystay/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/cozystay/auth/JwtAuthenticationFilter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -73,8 +74,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         // TODO: 커스텀 예외
                         .orElseThrow(() -> new RuntimeException("해당 ID의 회원을 찾을 수 없습니다."));
 
+                CustomOAuth2User customUser = new CustomOAuth2User(user, Map.of());
+
                 Authentication authentication = new UsernamePasswordAuthenticationToken(
-                        user, // Principal (인증된 주체, 여기서는 User 객체 자체를 넣음)
+                        customUser, // Principal (인증된 주체, 여기서는 User 객체 자체를 넣음)
                         null, // Credentials (자격 증명, JWT 방식에선 불필요)
                         Collections.singleton(new SimpleGrantedAuthority(user.getUserRole().getKey())) // 권한
                 );

--- a/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
@@ -32,12 +32,12 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-        Long kakaoId = oAuth2User.getAttribute("id");
+        Long providerId = oAuth2User.getAttribute("id");
 
-        log.info("카카오 로그인 성공. Kakao ID: {}", kakaoId);
+        log.info("카카오 로그인 성공. Kakao ID: {}", providerId);
 
-        User user = userRepository.findByKakaoId(kakaoId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. Kakao ID: " + kakaoId));
+        User user = userRepository.findByProviderId(providerId.toString())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. Provider ID: " + providerId));
 
         String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());

--- a/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
@@ -39,7 +39,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         User user = Optional.ofNullable(principal.getUser())
                 .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
 
-        log.info("카카오 로그인 성공. Kakao ID: {}", providerId);
+        log.info("로그인 성공!. Provider ID: {}", providerId);
 
         String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());

--- a/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/cozystay/auth/OAuth2LoginSuccessHandler.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -28,16 +29,17 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private String frontendUrl;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
 
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
 
-        Long providerId = oAuth2User.getAttribute("id");
+        Long providerId = principal.getAttribute("id");
+        User user = Optional.ofNullable(principal.getUser())
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
 
         log.info("카카오 로그인 성공. Kakao ID: {}", providerId);
-
-        User user = userRepository.findByProviderId(providerId.toString())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. Provider ID: " + providerId));
 
         String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());

--- a/src/main/java/com/project/cozystay/config/SecurityConfig.java
+++ b/src/main/java/com/project/cozystay/config/SecurityConfig.java
@@ -1,8 +1,11 @@
 package com.project.cozystay.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.cozystay.auth.CustomOAuth2UserService;
 import com.project.cozystay.auth.JwtAuthenticationFilter;
 import com.project.cozystay.auth.OAuth2LoginSuccessHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,8 +13,16 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Configuration
 @EnableWebSecurity
@@ -26,13 +37,20 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-                // 1. JWT 방식이므로 세션 STATELESS, CSRF/FormLogin/HttpBasic 비활성화
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                // JWT 방식이므로 세션 STATELESS, CSRF/FormLogin/HttpBasic 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
 
-                // 2. URL별 권한 설정
+                // 예외 처리 - 리다이렉트 대신 JSON 401
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(restAuthenticationEntryPoint())
+                )
+
+                // URL별 권한 설정
                 .authorizeHttpRequests(authz -> authz
                         // Swagger UI, H2 콘솔 등 개발 편의 기능 모두 허용
                         .requestMatchers("/swagger-ui.html", "/v3/api-docs/**", "/h2-console/**").permitAll()
@@ -44,7 +62,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
 
-                // 3. OAuth2 로그인 설정
+                // OAuth2 로그인 설정
                 .oauth2Login(oauth2 -> oauth2
 
                         // .../oauth2/authorization/{...}로 오는 요청들 처리
@@ -62,5 +80,51 @@ public class SecurityConfig {
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // 1. 허용할 프론트엔드 Origin
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        // 배포 후에는 "https://cozystay-frontend.com" 이런 거 추가
+
+        // 2. 허용 메서드
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+
+        // 3. 허용 헤더 (Authorization 포함)
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin"));
+
+        // 4. 인증정보(쿠키/Authorization 헤더) 포함 허용
+        config.setAllowCredentials(true);
+
+        // 5. Preflight 캐시 시간(초)
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        // 모든 경로에 대해 이 CORS 설정을 적용
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+
+    @Bean
+    public AuthenticationEntryPoint restAuthenticationEntryPoint() {
+        return (HttpServletRequest request,
+                HttpServletResponse response,
+                org.springframework.security.core.AuthenticationException authException) -> {
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+            response.setContentType("application/json;charset=UTF-8");
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("success", false);
+            body.put("message", "인증이 필요합니다.");
+            body.put("path", request.getRequestURI());
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.writeValue(response.getWriter(), body);
+        };
     }
 }

--- a/src/main/java/com/project/cozystay/user/controller/UserController.java
+++ b/src/main/java/com/project/cozystay/user/controller/UserController.java
@@ -1,0 +1,82 @@
+package com.project.cozystay.user.controller;
+
+import com.project.cozystay.auth.CustomOAuth2User;
+import com.project.cozystay.user.dto.*;
+import com.project.cozystay.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 내 프로필 조회 (마이페이지)
+     */
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ) {
+        Long userId = principal.getId();
+        UserProfileResponse response = userService.getMyProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 내 프로필 수정
+     */
+    @PatchMapping("/me/profile")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateMyProfile(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @RequestBody @Valid UserProfileUpdateRequest request
+    ) {
+        Long userId = principal.getId();
+        UserProfileResponse response = userService.updateMyProfile(userId, request);
+        return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다.", response));
+    }
+
+    /**
+     * 내 등급 / 통계 조회
+     */
+    @GetMapping("/me/grade")
+    public ResponseEntity<ApiResponse<UserGradeResponse>> getMyGrade(
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ) {
+        Long userId = principal.getId();
+        UserGradeResponse response = userService.getMyGrade(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 호스트 전환
+     */
+    @PostMapping("/me/host")
+    public ResponseEntity<ApiResponse<Void>> becomeHost(
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ) {
+        Long userId = principal.getId();
+        userService.becomeHost(userId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success("호스트로 전환되었습니다.", null));
+    }
+
+
+    /**
+     * 호스트 공개 프로필 조회
+     */
+    @GetMapping("/{userId}/public-profile")
+    public ResponseEntity<ApiResponse<PublicUserProfileResponse>> getPublicProfile(
+            @PathVariable Long userId
+    ) {
+        PublicUserProfileResponse response = userService.getPublicProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/project/cozystay/user/controller/UserController.java
+++ b/src/main/java/com/project/cozystay/user/controller/UserController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("api/users")
 public class UserController {
 
     private final UserService userService;

--- a/src/main/java/com/project/cozystay/user/controller/UserController.java
+++ b/src/main/java/com/project/cozystay/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.project.cozystay.user.controller;
 
 import com.project.cozystay.auth.CustomOAuth2User;
+import com.project.cozystay.user.domain.User;
 import com.project.cozystay.user.dto.*;
 import com.project.cozystay.user.service.UserService;
 import jakarta.validation.Valid;
@@ -24,8 +25,8 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile(
             @AuthenticationPrincipal CustomOAuth2User principal
     ) {
-        Long userId = principal.getId();
-        UserProfileResponse response = userService.getMyProfile(userId);
+        User user = principal.getUser();
+        UserProfileResponse response = userService.getMyProfile(user);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -37,7 +38,7 @@ public class UserController {
             @AuthenticationPrincipal CustomOAuth2User principal,
             @RequestBody @Valid UserProfileUpdateRequest request
     ) {
-        Long userId = principal.getId();
+        Long userId = principal.getUser().getId();
         UserProfileResponse response = userService.updateMyProfile(userId, request);
         return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다.", response));
     }
@@ -49,7 +50,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserGradeResponse>> getMyGrade(
             @AuthenticationPrincipal CustomOAuth2User principal
     ) {
-        Long userId = principal.getId();
+        Long userId = principal.getUser().getId();
         UserGradeResponse response = userService.getMyGrade(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -61,7 +62,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<Void>> becomeHost(
             @AuthenticationPrincipal CustomOAuth2User principal
     ) {
-        Long userId = principal.getId();
+        Long userId = principal.getUser().getId();
         userService.becomeHost(userId);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/project/cozystay/user/domain/AuthProvider.java
+++ b/src/main/java/com/project/cozystay/user/domain/AuthProvider.java
@@ -1,0 +1,16 @@
+package com.project.cozystay.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthProvider {
+
+    LOCAL("일반 회원가입"),
+    KAKAO("카카오"),
+    NAVER("네이버"),
+    GOOGLE("구글");
+
+    private final String description;
+}

--- a/src/main/java/com/project/cozystay/user/domain/UserGrade.java
+++ b/src/main/java/com/project/cozystay/user/domain/UserGrade.java
@@ -1,0 +1,16 @@
+package com.project.cozystay.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserGrade {
+
+    BRONZE("브론즈"),
+    SILVER("실버"),
+    GOLD("골드"),
+    PLATINUM("플래티넘");
+
+    private final String label;
+}

--- a/src/main/java/com/project/cozystay/user/domain/UserGrade.java
+++ b/src/main/java/com/project/cozystay/user/domain/UserGrade.java
@@ -7,10 +7,35 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserGrade {
 
-    BRONZE("브론즈"),
-    SILVER("실버"),
-    GOLD("골드"),
-    PLATINUM("플래티넘");
+    BRONZE(0, 0),
+    SILVER(5, 10),
+    GOLD(10, 20),
+    PLATINUM(20, 40);
 
-    private final String label;
+    private final int minBookings;
+    private final int minNights;
+
+    /**
+     * 다음 등급을 반환합니다.
+     * @return 다음 등급 (최고 등급이면 null 반환)
+     */
+    public UserGrade getNextGrade() {
+        int nextIndex = this.ordinal() + 1;
+        // 현재 등급이 마지막(PLATINUM)이면 null 반환
+        if (nextIndex >= values().length) {
+            return null;
+        }
+        return values()[nextIndex];
+    }
+
+    /**
+     * 해당 등급(this)을 달성하기 위해 남은 수치를 계산합니다.
+     */
+    public int calculateRemainingBookings(int currentBookings) {
+        return Math.max(0, this.minBookings - currentBookings);
+    }
+
+    public int calculateRemainingNights(int currentNights) {
+        return Math.max(0, this.minNights - currentNights);
+    }
 }

--- a/src/main/java/com/project/cozystay/user/dto/ApiResponse.java
+++ b/src/main/java/com/project/cozystay/user/dto/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.project.cozystay.user.dto;
+
+import lombok.Getter;
+
+/**
+ * 공통 응답 랩퍼
+ * @param <T>
+ */
+@Getter
+public class ApiResponse<T>{
+
+    private final boolean success;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(boolean success, String message, T data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, null, data);
+    }
+
+    public static <T> ApiResponse<T> fail(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+}

--- a/src/main/java/com/project/cozystay/user/dto/PublicUserProfileResponse.java
+++ b/src/main/java/com/project/cozystay/user/dto/PublicUserProfileResponse.java
@@ -1,0 +1,26 @@
+package com.project.cozystay.user.dto;
+
+import com.project.cozystay.user.domain.User;
+import lombok.Builder;
+
+/**
+ * 호스트 프로필 응답 DTO
+ */
+@Builder
+public record PublicUserProfileResponse(
+        Long id,
+        String nickName,
+        String profileImageUrl,
+        String grade,
+        int reviewCount
+) {
+    public static PublicUserProfileResponse from(User user) {
+        return PublicUserProfileResponse.builder()
+                .id(user.getId())
+                .nickName(user.getNickName())
+                .profileImageUrl(user.getProfileImageUrl())
+                .grade(user.getUserGrade().name())
+                .reviewCount(user.getReviewCount())
+                .build();
+    }
+}

--- a/src/main/java/com/project/cozystay/user/dto/UserGradeResponse.java
+++ b/src/main/java/com/project/cozystay/user/dto/UserGradeResponse.java
@@ -1,0 +1,30 @@
+package com.project.cozystay.user.dto;
+
+import com.project.cozystay.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record UserGradeResponse(
+        String grade,
+        int totalCompletedBookings,
+        int totalStayedNights,
+        int reviewCount,
+        String nextGrade,          // 예: "GOLD"
+        int remainingBookingsToNextGrade,
+        int remainingNightsToNextGrade
+) {
+    public static UserGradeResponse from(User user,
+                                         String nextGrade,
+                                         int remainingBookings,
+                                         int remainingNights) {
+        return UserGradeResponse.builder()
+                .grade(user.getUserGrade().name())
+                .totalCompletedBookings(user.getTotalCompletedBookings())
+                .totalStayedNights(user.getTotalStayedNights())
+                .reviewCount(user.getReviewCount())
+                .nextGrade(nextGrade)
+                .remainingBookingsToNextGrade(remainingBookings)
+                .remainingNightsToNextGrade(remainingNights)
+                .build();
+    }
+}

--- a/src/main/java/com/project/cozystay/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/project/cozystay/user/dto/UserProfileResponse.java
@@ -1,0 +1,28 @@
+package com.project.cozystay.user.dto;
+
+import com.project.cozystay.user.domain.User;
+import lombok.Builder;
+
+/**
+ * 내 프로필 응답 DTO
+ */
+@Builder
+public record UserProfileResponse(
+        Long id,
+        String email,
+        String nickName,
+        String profileImageUrl,
+        String role,      // USER / HOST / ADMIN
+        String grade      // BRONZE / SILVER / GOLD / PLATINUM
+) {
+    public static UserProfileResponse from(User user) {
+        return UserProfileResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickName(user.getNickName())
+                .profileImageUrl(user.getProfileImageUrl())
+                .role(user.getUserRole().name())
+                .grade(user.getUserGrade().name())
+                .build();
+    }
+}

--- a/src/main/java/com/project/cozystay/user/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/project/cozystay/user/dto/UserProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.project.cozystay.user.dto;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 프로필 수정 요청 DTO
+ */
+public record UserProfileUpdateRequest(
+        @Size(min = 1, max = 30)
+        String nickName,
+        String profileImageUrl
+) {
+}

--- a/src/main/java/com/project/cozystay/user/repository/UserRepository.java
+++ b/src/main/java/com/project/cozystay/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.project.cozystay.user.repository;
 
+import com.project.cozystay.user.domain.AuthProvider;
 import com.project.cozystay.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,5 +9,12 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     // 카카오 ID로 회원 조회
-    Optional<User> findByKakaoId(Long kakaoId);
+    Optional<User> findByProviderId(String providerId);
+
+    // DB PK ID로 회원 조회
+    Optional<User> findUserById(Long userId);
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 }

--- a/src/main/java/com/project/cozystay/user/repository/UserRepository.java
+++ b/src/main/java/com/project/cozystay/user/repository/UserRepository.java
@@ -11,9 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 카카오 ID로 회원 조회
     Optional<User> findByProviderId(String providerId);
 
-    // DB PK ID로 회원 조회
-    Optional<User> findUserById(Long userId);
-
     Optional<User> findByEmail(String email);
 
     Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);

--- a/src/main/java/com/project/cozystay/user/repository/UserRepository.java
+++ b/src/main/java/com/project/cozystay/user/repository/UserRepository.java
@@ -8,10 +8,11 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    // 카카오 ID로 회원 조회
+    // Provider ID로 회원 조회
     Optional<User> findByProviderId(String providerId);
 
-    Optional<User> findByEmail(String email);
+    // Provider ID와 Provider 로 회원 조회
+    Optional<User> findByProviderIdAndProvider(String providerId, AuthProvider provider);
 
     Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 }

--- a/src/main/java/com/project/cozystay/user/service/UserService.java
+++ b/src/main/java/com/project/cozystay/user/service/UserService.java
@@ -1,0 +1,20 @@
+package com.project.cozystay.user.service;
+
+import com.project.cozystay.user.dto.PublicUserProfileResponse;
+import com.project.cozystay.user.dto.UserGradeResponse;
+import com.project.cozystay.user.dto.UserProfileResponse;
+import com.project.cozystay.user.dto.UserProfileUpdateRequest;
+
+public interface UserService {
+
+    UserProfileResponse getMyProfile(Long userId);
+
+    UserGradeResponse getMyGrade(Long userId);
+
+    UserProfileResponse updateMyProfile(Long userId, UserProfileUpdateRequest request);
+
+    void becomeHost(Long userId);
+
+    PublicUserProfileResponse getPublicProfile(Long userId);
+
+}

--- a/src/main/java/com/project/cozystay/user/service/UserService.java
+++ b/src/main/java/com/project/cozystay/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.project.cozystay.user.service;
 
+import com.project.cozystay.user.domain.User;
 import com.project.cozystay.user.dto.PublicUserProfileResponse;
 import com.project.cozystay.user.dto.UserGradeResponse;
 import com.project.cozystay.user.dto.UserProfileResponse;
@@ -7,7 +8,7 @@ import com.project.cozystay.user.dto.UserProfileUpdateRequest;
 
 public interface UserService {
 
-    UserProfileResponse getMyProfile(Long userId);
+    UserProfileResponse getMyProfile(User user);
 
     UserGradeResponse getMyGrade(Long userId);
 

--- a/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
@@ -1,0 +1,135 @@
+package com.project.cozystay.user.service;
+
+import com.project.cozystay.user.domain.Role;
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.domain.UserGrade;
+import com.project.cozystay.user.dto.PublicUserProfileResponse;
+import com.project.cozystay.user.dto.UserGradeResponse;
+import com.project.cozystay.user.dto.UserProfileResponse;
+import com.project.cozystay.user.dto.UserProfileUpdateRequest;
+import com.project.cozystay.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+    /* 등급 기준 예시 (횟수/박수 기준) */
+    private static final int SILVER_BOOKING_THRESHOLD = 5;
+    private static final int SILVER_NIGHTS_THRESHOLD = 10;
+
+    private static final int GOLD_BOOKING_THRESHOLD = 10;
+    private static final int GOLD_NIGHTS_THRESHOLD = 20;
+
+    private static final int PLATINUM_BOOKING_THRESHOLD = 20;
+    private static final int PLATINUM_NIGHTS_THRESHOLD = 40;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserProfileResponse getMyProfile(Long userId) {
+        User user = getUserOrThrow(userId);
+        return UserProfileResponse.from(user);
+    }
+
+    @Override
+    public UserProfileResponse updateMyProfile(Long userId, UserProfileUpdateRequest request) {
+        User user = getUserOrThrow(userId);
+
+        user.updateNicknameAndProfile(request.nickName(), request.profileImageUrl());
+
+        // JPA 변경 감지로 자동 flush
+        return UserProfileResponse.from(user);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserGradeResponse getMyGrade(Long userId) {
+        User user = getUserOrThrow(userId);
+
+        GradeInfo nextGradeInfo = calculateNextGradeInfo(user);
+
+        return UserGradeResponse.from(
+                user,
+                nextGradeInfo.nextGradeName(),
+                nextGradeInfo.remainingBookings(),
+                nextGradeInfo.remainingNights()
+        );
+    }
+
+    @Override
+    public void becomeHost(Long userId) {
+        User user = getUserOrThrow(userId);
+
+        // 이미 HOST/ADMIN이면 예외
+        if (user.getUserRole() == Role.HOST || user.getUserRole() == Role.ADMIN) {
+            throw new IllegalStateException("이미 호스트 권한을 가지고 있습니다.");
+        }
+
+        // TODO: 여기서 호스트 전환에 필요한 추가 정보(전화번호, 계좌 등) 검증 로직 넣어도 됨
+        user.changeRole(Role.HOST);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PublicUserProfileResponse getPublicProfile(Long userId) {
+        User user = getUserOrThrow(userId);
+
+        return PublicUserProfileResponse.from(user);
+    }
+
+
+    // ======= 내부 공통 메서드 =======
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. id=" + userId));
+    }
+
+    /**
+     * 다음 등급과, 그 등급까지 필요한 예약 수/박 수 계산
+     * - 단순 로직 예시, 나중에 바뀌어도 여기만 손대면 됨
+     */
+    private GradeInfo calculateNextGradeInfo(User user) {
+        UserGrade currentGrade = user.getUserGrade();
+        int bookings = user.getTotalCompletedBookings();
+        int nights = user.getTotalStayedNights();
+
+        // 이미 최고 등급이면 "다음 등급 없음"
+        if (currentGrade == UserGrade.PLATINUM) {
+            return new GradeInfo("NONE", 0, 0);
+        }
+
+        // 다음 등급 기준
+        if (currentGrade == UserGrade.BRONZE) {
+            int remainingBookings = Math.max(0, SILVER_BOOKING_THRESHOLD - bookings);
+            int remainingNights = Math.max(0, SILVER_NIGHTS_THRESHOLD - nights);
+            return new GradeInfo(UserGrade.SILVER.name(), remainingBookings, remainingNights);
+        }
+
+        if (currentGrade == UserGrade.SILVER) {
+            int remainingBookings = Math.max(0, GOLD_BOOKING_THRESHOLD - bookings);
+            int remainingNights = Math.max(0, GOLD_NIGHTS_THRESHOLD - nights);
+            return new GradeInfo(UserGrade.GOLD.name(), remainingBookings, remainingNights);
+        }
+
+        // currentGrade == GOLD 인 경우
+        int remainingBookings = Math.max(0, PLATINUM_BOOKING_THRESHOLD - bookings);
+        int remainingNights = Math.max(0, PLATINUM_NIGHTS_THRESHOLD - nights);
+        return new GradeInfo(UserGrade.PLATINUM.name(), remainingBookings, remainingNights);
+    }
+
+    /**
+     * 내부에서만 쓰는 작은 값 객체
+     */
+    private record GradeInfo(
+            String nextGradeName,
+            int remainingBookings,
+            int remainingNights
+    ) {
+    }
+}

--- a/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
@@ -95,31 +95,18 @@ public class UserServiceImpl implements UserService{
      */
     private GradeInfo calculateNextGradeInfo(User user) {
         UserGrade currentGrade = user.getUserGrade();
-        int bookings = user.getTotalCompletedBookings();
-        int nights = user.getTotalStayedNights();
+        UserGrade nextGrade = currentGrade.getNextGrade();
 
-        // 이미 최고 등급이면 "다음 등급 없음"
-        if (currentGrade == UserGrade.PLATINUM) {
-            return new GradeInfo("NONE", 0, 0);
+        // 최고 등급인 경우 (다음 등급이 없음)
+        if (nextGrade == null) {
+            return new GradeInfo("PLATINUM", 0, 0);
         }
 
-        // 다음 등급 기준
-        if (currentGrade == UserGrade.BRONZE) {
-            int remainingBookings = Math.max(0, SILVER_BOOKING_THRESHOLD - bookings);
-            int remainingNights = Math.max(0, SILVER_NIGHTS_THRESHOLD - nights);
-            return new GradeInfo(UserGrade.SILVER.name(), remainingBookings, remainingNights);
-        }
+        // 다음 등급까지 남은 실적 계산
+        int remainingBookings = nextGrade.calculateRemainingBookings(user.getTotalCompletedBookings());
+        int remainingNights = nextGrade.calculateRemainingNights(user.getTotalStayedNights());
 
-        if (currentGrade == UserGrade.SILVER) {
-            int remainingBookings = Math.max(0, GOLD_BOOKING_THRESHOLD - bookings);
-            int remainingNights = Math.max(0, GOLD_NIGHTS_THRESHOLD - nights);
-            return new GradeInfo(UserGrade.GOLD.name(), remainingBookings, remainingNights);
-        }
-
-        // currentGrade == GOLD 인 경우
-        int remainingBookings = Math.max(0, PLATINUM_BOOKING_THRESHOLD - bookings);
-        int remainingNights = Math.max(0, PLATINUM_NIGHTS_THRESHOLD - nights);
-        return new GradeInfo(UserGrade.PLATINUM.name(), remainingBookings, remainingNights);
+        return new GradeInfo(nextGrade.name(), remainingBookings, remainingNights);
     }
 
     /**

--- a/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
@@ -31,8 +31,7 @@ public class UserServiceImpl implements UserService{
 
     @Override
     @Transactional(readOnly = true)
-    public UserProfileResponse getMyProfile(Long userId) {
-        User user = getUserOrThrow(userId);
+    public UserProfileResponse getMyProfile(User user) {
         return UserProfileResponse.from(user);
     }
 


### PR DESCRIPTION
## 🔗 반영 브랜치

(#6) feature/user -> develop

## 📝 작업 내용
- User 도메인 리팩터링 및 User CRUD/API 구현
- 카카오 전용 로그인 구조 → 다양한 로그인 방식(LOCAL/KAKAO/NAVER/GOOGLE) 확장 가능한 구조로 변경
- 유저 등급(Grade) 및 통계 필드 추가, 호스트 전환/공개 프로필 조회 API 추가

## 💬 리뷰 요구사항
- 회원탈퇴 기능은 미구현