### PR TITLE
Feat: 숙소 수정, 삭제 기능 구현 및 CustomOAuth2User 적용

### DIFF
--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -1,9 +1,13 @@
 package com.project.cozystay.accommodation.controller;
 
+import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.dto.*;
 import com.project.cozystay.accommodation.service.AccommodationService;
+import com.project.cozystay.auth.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,48 +19,150 @@ public class AccommodationController {
 
     private final AccommodationService accommodationService;
 
+    /**
+     * 숙소 정보 조회 (메인 페이지)
+     */
     @GetMapping
     public ResponseEntity<List<AccommodationResponseDTO>> getAccommodations() {
         List<AccommodationResponseDTO> response =  accommodationService.getAllAccommodations();
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 숙소 생성
+     */
     @PostMapping
-    public ResponseEntity<AccommodationResponseDTO> createAccommodation(@RequestBody AccommodationRequestDTO request) {
-        AccommodationResponseDTO response = accommodationService.createAccommodation(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<AccommodationResponseDTO> createAccommodation(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @RequestBody AccommodationRequestDTO request
+    ) {
+        Long hostId = principal.getId();
+        AccommodationResponseDTO response = accommodationService.createAccommodation(request, hostId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    /**
+     * 숙소 상세정보 생성
+     */
     @PostMapping("/details/{accommodationId}")
-    public ResponseEntity<AccommodationDetailResponseDTO> addAccommodationDetail(@PathVariable Long accommodationId, @RequestBody AccommodationDetailRequestDTO request) {
-        AccommodationDetailResponseDTO response = accommodationService.addAccommodationDetail(accommodationId, request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<AccommodationDetailResponseDTO> addAccommodationDetail(
+            @PathVariable Long accommodationId,
+            @RequestBody AccommodationDetailRequestDTO request,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ) {
+        Long hostId = principal.getId();
+        AccommodationDetailResponseDTO response = accommodationService.addAccommodationDetail(accommodationId, hostId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    /**
+     * 숙소 상세정보 조회
+     */
     @GetMapping("/{accommodationId}")
-    public ResponseEntity<AccommodationFullResponseDTO> getAccommodationDetail(@PathVariable Long accommodationId) {
+    public ResponseEntity<AccommodationFullResponseDTO> getAccommodationDetail(
+            @PathVariable Long accommodationId
+    ) {
         AccommodationFullResponseDTO response = accommodationService.getAccommodationDetail(accommodationId);
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 숙소 상태 변경(DRAFT -> ACTIVE)
+     */
     @PatchMapping("/{accommodationId}/publish")
-    public ResponseEntity<Void> changePublish(@PathVariable Long accommodationId) {
-        accommodationService.publish(accommodationId);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Void> changePublish(
+            @PathVariable Long accommodationId,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ) {
+        Long hostId = principal.getId();
+        accommodationService.publish(accommodationId, hostId);
+        return ResponseEntity.noContent().build();
     }
 
+    /**
+     * 숙소 이미지 추가
+     */
     @PostMapping("/images/{accommodationId}")
-    public ResponseEntity<AccommodationImageResponseDTO> addImage(@PathVariable Long accommodationId, @RequestBody List<AccommodationImageRequestDTO> request){
-        AccommodationImageResponseDTO response = accommodationService.addImage(accommodationId, request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<AccommodationImageResponseDTO> addImage(
+            @PathVariable Long accommodationId,
+            @RequestBody List<AccommodationImageRequestDTO> request,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ){
+        Long hostId = principal.getId();
+        AccommodationImageResponseDTO response = accommodationService.addImage(accommodationId, hostId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    /**
+     * 숙소 편의시설 (어매니티) 추가
+     */
     @PostMapping("/amenities/{accommodationId}")
-    public ResponseEntity<AccommodationAmenityResponseDTO> addAmenities(@PathVariable Long accommodationId, @RequestBody List<AccommodationAmenityRequestDTO> request){
-        AccommodationAmenityResponseDTO response = accommodationService.addAmenities(accommodationId, request);
+    public ResponseEntity<AccommodationAmenityResponseDTO> addAmenities(
+            @PathVariable Long accommodationId,
+            @RequestBody List<AccommodationAmenityRequestDTO> request,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ){
+        Long hostId = principal.getId();
+        AccommodationAmenityResponseDTO response = accommodationService.addAmenities(accommodationId, hostId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 숙소 삭제
+     */
+    @DeleteMapping("/{accommodationId}")
+    public ResponseEntity<AccommodationDeleteResponseDTO> deleteAccommodation(
+            @PathVariable Long accommodationId,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ){
+        Long hostId = principal.getId();
+        AccommodationDeleteResponseDTO response = accommodationService.deleteAccommodation(accommodationId, hostId);
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 숙소 기본정보 수정
+     */
+    @PatchMapping("/{accommodationId}")
+    public ResponseEntity<AccommodationUpdateResponseDTO> updateAccommodation(
+            @PathVariable Long accommodationId,
+            @RequestBody AccommodationUpdateRequestDTO request,
+            @AuthenticationPrincipal CustomOAuth2User principal
+
+    ){
+        Long hostId = principal.getId();
+        AccommodationUpdateResponseDTO response = accommodationService.updateAccommodation(accommodationId, hostId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 숙소 상세 정보 수정
+     */
+    @PatchMapping("/{accommodationId}/details")
+    public ResponseEntity<AccommodationDetailUpdateResponseDTO> updateAccommodationDetail(
+            @PathVariable Long accommodationId,
+            @RequestBody AccommodationDetailUpdateRequestDTO request,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ){
+        Long hostId = principal.getId();
+        AccommodationDetailUpdateResponseDTO response = accommodationService.updateAccommodationDetail(accommodationId, hostId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 숙소 이미지 삭제
+     */
+    @DeleteMapping("/{accommodationId}/images")
+    public ResponseEntity<AccommodationImageDeleteResponseDTO> deleteAccommodationImages(
+            @PathVariable Long accommodationId,
+            @RequestBody AccommodationImageDeleteRequestDTO request,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ){
+        Long hostId = principal.getId();
+        AccommodationImageDeleteResponseDTO response = accommodationService.deleteAccommodationImages(accommodationId, hostId, request);
+        return ResponseEntity.ok(response);
 
     }
+
+}
 

--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -155,11 +155,11 @@ public class AccommodationController {
     @DeleteMapping("/{accommodationId}/images")
     public ResponseEntity<AccommodationImageDeleteResponseDTO> deleteAccommodationImages(
             @PathVariable Long accommodationId,
-            @RequestBody AccommodationImageDeleteRequestDTO request,
+            @RequestParam List<Long> imageIds,
             @AuthenticationPrincipal CustomOAuth2User principal
     ){
         Long hostId = principal.getId();
-        AccommodationImageDeleteResponseDTO response = accommodationService.deleteAccommodationImages(accommodationId, hostId, request);
+        AccommodationImageDeleteResponseDTO response = accommodationService.deleteAccommodationImages(accommodationId, hostId, imageIds);
         return ResponseEntity.ok(response);
 
     }

--- a/src/main/java/com/project/cozystay/accommodation/domain/Accommodation.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/Accommodation.java
@@ -1,4 +1,5 @@
 package com.project.cozystay.accommodation.domain;
+import com.project.cozystay.accommodation.dto.AccommodationUpdateRequestDTO;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,11 +19,9 @@ public class Accommodation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "accommodation_id")
-    private Long accommodationId;
+    private Long id;
 
     @Column(name = "host_id", nullable = false)
-    //ManyToOne(fetch = FetchType.LAZY)
-    //@JoinColumn(name = "host_id")
     private Long hostId;
 
     @Column(nullable = false, length = 200)
@@ -139,6 +138,42 @@ public class Accommodation {
             throw new IllegalStateException("편의시설 정보가 없습니다.");
 
         this.status = AccommodationStatus.ACTIVE;
+    }
+
+    public void update(AccommodationUpdateRequestDTO dto){
+        if (dto.getTitle() != null) this.title = dto.getTitle();
+
+        if (dto.getDescription() != null) this.description = dto.getDescription();
+
+        if (dto.getAccommodationType() != null) this.accommodationType = dto.getAccommodationType();
+
+        if (dto.getAddress() != null) this.address = dto.getAddress();
+
+        if (dto.getCity() != null) this.city = dto.getCity();
+
+        if (dto.getState() != null) this.state = dto.getState();
+
+        if (dto.getCountry() != null) this.country = dto.getCountry();
+
+        if (dto.getPostalCode() != null) this.postalCode = dto.getPostalCode();
+
+        if (dto.getLatitude() != null) this.latitude = dto.getLatitude();
+
+        if (dto.getLongitude() != null) this.longitude = dto.getLongitude();
+
+        if (dto.getMaxGuests() != null) this.maxGuests = dto.getMaxGuests();
+
+        if (dto.getPricePerNight() != null) this.pricePerNight = dto.getPricePerNight();
+
+        if (dto.getCleaningFee() != null) this.cleaningFee = dto.getCleaningFee();
+
+        if (dto.getServiceFeePercentage() != null) this.serviceFeePercentage = dto.getServiceFeePercentage();
+
+        if (dto.getInstantBooking() != null) this.instantBooking = dto.getInstantBooking();
+
+        if (dto.getCheckInTime() != null) this.checkInTime = dto.getCheckInTime();
+
+        if (dto.getCheckOutTime() != null) this.checkOutTime = dto.getCheckOutTime();
     }
 
 }

--- a/src/main/java/com/project/cozystay/accommodation/domain/AccommodationAmenity.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/AccommodationAmenity.java
@@ -30,8 +30,8 @@ public class AccommodationAmenity {
         this.accommodation = accommodation;
         this.amenity = amenity;
         this.id = new AccommodationAmenityId(
-                accommodation.getAccommodationId(),
-                amenity.getAmenityId()
+                accommodation.getId(),
+                amenity.getId()
         );
     }
 

--- a/src/main/java/com/project/cozystay/accommodation/domain/AccommodationDetail.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/AccommodationDetail.java
@@ -1,6 +1,7 @@
 package com.project.cozystay.accommodation.domain;
 
 
+import com.project.cozystay.accommodation.dto.AccommodationDetailUpdateRequestDTO;
 import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -15,7 +16,7 @@ import lombok.*;
 public class AccommodationDetail {
     @Id
     @Column(name = "accommodation_id")
-    private Long accommodationId;
+    private Long id;
 
     @MapsId
     @OneToOne(fetch = FetchType.LAZY)
@@ -66,5 +67,36 @@ public class AccommodationDetail {
 
     void assignAccommodation(Accommodation accommodation){
         this.accommodation = accommodation;
+    }
+
+    public void update(AccommodationDetailUpdateRequestDTO dto) {
+
+        if (dto.getRoomCount() != null) this.roomCount = dto.getRoomCount();
+
+        if (dto.getBedroomCount() != null) this.bedroomCount = dto.getBedroomCount();
+
+        if (dto.getBedCount() != null) this.bedCount = dto.getBedCount();
+
+        if (dto.getBathroomCount() != null) this.bathroomCount = dto.getBathroomCount();
+
+        if (dto.getAirConditionerCount() != null) this.airConditionerCount = dto.getAirConditionerCount();
+
+        if (dto.getHairDryerCount() != null) this.hairDryerCount = dto.getHairDryerCount();
+
+        if (dto.getRefrigeratorCount() != null) this.refrigeratorCount = dto.getRefrigeratorCount();
+
+        if (dto.getTelevisionCount() != null) this.televisionCount = dto.getTelevisionCount();
+
+        if (dto.getWasherCount() != null) this.washerCount = dto.getWasherCount();
+
+        if (dto.getDryerCount() != null) this.dryerCount = dto.getDryerCount();
+
+        if (dto.getWifiAvailable() != null) this.wifiAvailable = dto.getWifiAvailable();
+
+        if (dto.getParkingAvailable() != null) this.parkingAvailable = dto.getParkingAvailable();
+
+        if (dto.getPetAvailable() != null) this.petAvailable = dto.getPetAvailable();
+
+        if (dto.getKitchenAvailable() != null) this.kitchenAvailable = dto.getKitchenAvailable();
     }
 }

--- a/src/main/java/com/project/cozystay/accommodation/domain/AccommodationImage.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/AccommodationImage.java
@@ -17,8 +17,8 @@ public class AccommodationImage {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column
-    private Long imageId;
+    @Column(name = "image_id")
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "accommodation_id")

--- a/src/main/java/com/project/cozystay/accommodation/domain/Amenity.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/Amenity.java
@@ -19,7 +19,7 @@ public class Amenity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "amenity_id")
-    private Integer amenityId;
+    private Integer id;
 
     @Column(nullable = false, length = 100)
     private String name;

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDeleteResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDeleteResponseDTO.java
@@ -1,0 +1,13 @@
+package com.project.cozystay.accommodation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AccommodationDeleteResponseDTO {
+    private Long accommodationId;
+    private String message;
+}

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDetailUpdateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDetailUpdateRequestDTO.java
@@ -1,0 +1,26 @@
+package com.project.cozystay.accommodation.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccommodationDetailUpdateRequestDTO {
+    private Integer roomCount;
+    private Integer bedroomCount;
+    private Integer bedCount;
+    private Integer bathroomCount;
+    private Integer airConditionerCount;
+    private Integer hairDryerCount;
+    private Integer refrigeratorCount;
+    private Integer televisionCount;
+    private Integer washerCount;
+    private Integer dryerCount;
+    private Boolean wifiAvailable;
+    private Boolean parkingAvailable;
+    private Boolean petAvailable;
+    private Boolean kitchenAvailable;
+}

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDetailUpdateResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDetailUpdateResponseDTO.java
@@ -1,0 +1,14 @@
+package com.project.cozystay.accommodation.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AccommodationDetailUpdateResponseDTO {
+    private Long accommodationId;
+    private String message;
+}

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
@@ -62,7 +62,7 @@ public class AccommodationFullResponseDTO {
     public static AccommodationFullResponseDTO fromEntity(Accommodation entity) {
 
         return AccommodationFullResponseDTO.builder()
-                .accommodationId(entity.getAccommodationId())
+                .accommodationId(entity.getId())
                 .hostId(entity.getHostId())
                 .title(entity.getTitle())
                 .description(entity.getDescription())
@@ -90,7 +90,7 @@ public class AccommodationFullResponseDTO {
                 .images(
                         entity.getImages().stream()
                                 .map(i -> AccommodationImageDTO.builder()
-                                        .imageId(i.getImageId())
+                                        .imageId(i.getId())
                                         .imageUrl(i.getImageUrl())
                                         .displayOrder(i.getDisplayOrder())
                                         .isPrimary(i.isPrimary())
@@ -100,7 +100,7 @@ public class AccommodationFullResponseDTO {
                 .amenities(
                         entity.getAmenities().stream()
                                 .map(a -> AmenityDTO.builder()
-                                        .amenityId(a.getAmenity().getAmenityId())
+                                        .amenityId(a.getAmenity().getId())
                                         .name(a.getAmenity().getName())
                                         .icon(a.getAmenity().getIcon())
                                         .category(a.getAmenity().getCategory())

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageDeleteRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageDeleteRequestDTO.java
@@ -1,0 +1,14 @@
+package com.project.cozystay.accommodation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccommodationImageDeleteRequestDTO {
+    private List<Long> imageIds;
+}

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageDeleteResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageDeleteResponseDTO.java
@@ -1,0 +1,18 @@
+package com.project.cozystay.accommodation.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AccommodationImageDeleteResponseDTO {
+    private List<Long> imageIds;
+    private String message;
+}

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
@@ -15,7 +15,6 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AccommodationRequestDTO {
-    private Long hostId;
 
     private String title;
 
@@ -51,9 +50,9 @@ public class AccommodationRequestDTO {
 
     private LocalTime checkOutTime;
 
-    public Accommodation toEntity() {
+    public Accommodation toEntity(Long hostId) {
         return Accommodation.builder()
-                .hostId(this.hostId)
+                .hostId(hostId)
                 .title(this.title)
                 .description(this.description)
                 .accommodationType(this.accommodationType)

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationResponseDTO.java
@@ -22,7 +22,7 @@ public class AccommodationResponseDTO {
 
     public static AccommodationResponseDTO fromEntity(Accommodation entity) {
         return new AccommodationResponseDTO(
-                entity.getAccommodationId(),
+                entity.getId(),
                 entity.getTitle(),
                 entity.getImages().stream()
                         .map(AccommodationImage::getImageUrl)

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
@@ -1,0 +1,34 @@
+package com.project.cozystay.accommodation.dto;
+
+
+import com.project.cozystay.accommodation.domain.AccommodationType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccommodationUpdateRequestDTO {
+    private String title;
+    private String description;
+    private AccommodationType accommodationType;
+    private String address;
+    private String city;
+    private String state;
+    private String country;
+    private String postalCode;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private Integer maxGuests;
+    private BigDecimal pricePerNight;
+    private BigDecimal cleaningFee;
+    private BigDecimal serviceFeePercentage;
+    private Boolean instantBooking;
+    private LocalTime checkInTime;
+    private LocalTime checkOutTime;
+
+}

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateResponseDTO.java
@@ -1,0 +1,16 @@
+package com.project.cozystay.accommodation.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccommodationUpdateResponseDTO {
+    private Long accommodationId;
+    private String title;
+}

--- a/src/main/java/com/project/cozystay/accommodation/repository/AccommodationImageRepository.java
+++ b/src/main/java/com/project/cozystay/accommodation/repository/AccommodationImageRepository.java
@@ -2,6 +2,15 @@ package com.project.cozystay.accommodation.repository;
 
 import com.project.cozystay.accommodation.domain.AccommodationImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface AccommodationImageRepository extends JpaRepository <AccommodationImage, Long> {
+    @Query("""
+            SELECT ai
+            FROM AccommodationImage ai
+            WHERE ai.id IN :imageids AND ai.accommodation.id = :accommodationId
+            """)
+    List<AccommodationImage> findAllByIdInAndAccommodationId(List<Long> imageIds, Long accommodationId);
 }

--- a/src/main/java/com/project/cozystay/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/com/project/cozystay/accommodation/repository/AccommodationRepository.java
@@ -24,7 +24,7 @@ LEFT JOIN FETCH a.detail
 LEFT JOIN FETCH a.images
 LEFT JOIN FETCH a.amenities am
 LEFT JOIN FETCH am.amenity
-WHERE a.accommodationId = :id
+WHERE a.id = :id
 """)
     Optional<Accommodation> findDetailById(Long id);
 }

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -32,8 +32,8 @@ public class AccommodationService {
     }
 
     @Transactional
-    public AccommodationResponseDTO createAccommodation(AccommodationRequestDTO request) {
-        Accommodation accommodation = request.toEntity();
+    public AccommodationResponseDTO createAccommodation(AccommodationRequestDTO request, Long hostId) {
+        Accommodation accommodation = request.toEntity(hostId);
 
         accommodationRepository.save(accommodation);
 
@@ -41,11 +41,12 @@ public class AccommodationService {
     }
 
     @Transactional
-    public AccommodationDetailResponseDTO addAccommodationDetail(Long accommodationId, AccommodationDetailRequestDTO request) {
+    public AccommodationDetailResponseDTO addAccommodationDetail(Long accommodationId, Long hostId, AccommodationDetailRequestDTO request) {
 
-        // 숙소 ID 조회
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+
+       accommodationHostCheck(accommodation, hostId);
 
         AccommodationDetail detail = request.toEntity();
 
@@ -68,17 +69,21 @@ public class AccommodationService {
     }
 
     @Transactional
-    public void publish(Long accommodationId){
+    public void publish(Long accommodationId, Long hostId){
         Accommodation accommodation = accommodationRepository.findDetailById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+
+        accommodationHostCheck(accommodation, hostId);
 
         accommodation.publish();
     }
 
     @Transactional
-    public AccommodationImageResponseDTO addImage(Long accommodationId, List<AccommodationImageRequestDTO> request) {
+    public AccommodationImageResponseDTO addImage(Long accommodationId, Long hostId, List<AccommodationImageRequestDTO> request) {
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다"));
+
+        accommodationHostCheck(accommodation, hostId);
 
         List<AccommodationImage> newImages = new ArrayList<>();
 
@@ -91,7 +96,7 @@ public class AccommodationService {
         accommodationRepository.save(accommodation);
 
         List<Long> imageIds = newImages.stream()
-                .map(AccommodationImage::getImageId)
+                .map(AccommodationImage::getId)
                 .toList();
 
         return AccommodationImageResponseDTO.builder()
@@ -102,9 +107,11 @@ public class AccommodationService {
     }
 
     @Transactional
-    public AccommodationAmenityResponseDTO addAmenities(Long accommodationId, List<AccommodationAmenityRequestDTO> request){
+    public AccommodationAmenityResponseDTO addAmenities(Long accommodationId, Long hostId, List<AccommodationAmenityRequestDTO> request){
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다"));
+
+        accommodationHostCheck(accommodation, hostId);
 
         for (AccommodationAmenityRequestDTO dto : request) {
             Amenity amenity = amenityRepository.findByName(dto.getName())
@@ -125,5 +132,99 @@ public class AccommodationService {
                 .count(request.size())
                 .message("편의시설 등록 완료")
                 .build();
+    }
+
+    //Cascade 설정에 의해 연관관계를 맺고 있는 테이블도 함께 삭제
+    @Transactional
+    public AccommodationDeleteResponseDTO deleteAccommodation(Long accommodationId, Long hostId){
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다"));
+
+        accommodationHostCheck(accommodation, hostId);
+
+        accommodationRepository.delete(accommodation);
+
+        return AccommodationDeleteResponseDTO.builder()
+                .accommodationId(accommodationId)
+                .message("숙소가 삭제되었습니다")
+                .build();
+    }
+
+    @Transactional
+    public AccommodationUpdateResponseDTO updateAccommodation(
+            Long accommodationId,
+            Long hostId,
+            AccommodationUpdateRequestDTO request
+    ){
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+
+        accommodationHostCheck(accommodation, hostId);
+
+        accommodation.update(request);
+
+        return AccommodationUpdateResponseDTO.builder()
+                .accommodationId(accommodation.getId())
+                .title(accommodation.getTitle())
+                .build();
+    }
+
+    @Transactional
+    public AccommodationDetailUpdateResponseDTO updateAccommodationDetail(
+            Long accommodationId,
+            Long hostId,
+            AccommodationDetailUpdateRequestDTO request
+    ){
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+                .orElseThrow(()-> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+
+        accommodationHostCheck(accommodation, hostId);
+
+        //AccommodationDetail 엔티티도 영속 상태로 진입
+        AccommodationDetail detail = accommodation.getDetail();
+        if(detail == null){
+            throw new IllegalStateException("상세 정보가 존재하지 않습니다.");
+        }
+
+        detail.update(request);
+
+        return AccommodationDetailUpdateResponseDTO.builder()
+                .accommodationId(accommodation.getId())
+                .message("숙소 상세정보 수정 완료")
+                .build();
+    }
+
+    @Transactional
+    public AccommodationImageDeleteResponseDTO deleteAccommodationImages(
+            Long accommodationId, Long hostId, AccommodationImageDeleteRequestDTO request
+    ){
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+
+        accommodationHostCheck(accommodation, hostId);
+
+        List<AccommodationImage> images = accommodationImageRepository.findAllById(request.getImageIds());
+
+        for (AccommodationImage img : images){
+            if(!img.getAccommodation().getId().equals(accommodationId)){
+                throw new IllegalArgumentException("이미지가 해당 숙소에 속하지 않습니다.");
+            }
+        }
+
+        accommodationImageRepository.deleteAll(images);
+
+        return AccommodationImageDeleteResponseDTO.builder()
+                .imageIds(request.getImageIds())
+                .message("이미지 삭제 완료")
+                .build();
+    }
+
+    /**
+     * 숙소의 주인과 요청한 사람이 맞는지 비교하는 공통 메서드
+     */
+    private void accommodationHostCheck(Accommodation accommodation, Long hostId){
+        if (!accommodation.getHostId().equals(hostId)){
+            throw new IllegalStateException("숙소의 소유자만 수정할 수 있습니다.");
+        }
     }
 }

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -196,25 +196,23 @@ public class AccommodationService {
 
     @Transactional
     public AccommodationImageDeleteResponseDTO deleteAccommodationImages(
-            Long accommodationId, Long hostId, AccommodationImageDeleteRequestDTO request
+            Long accommodationId, Long hostId, List<Long> imageIds
     ){
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
 
         accommodationHostCheck(accommodation, hostId);
 
-        List<AccommodationImage> images = accommodationImageRepository.findAllById(request.getImageIds());
+        List<AccommodationImage> images = accommodationImageRepository.findAllByIdInAndAccommodationId(imageIds, accommodationId);
 
-        for (AccommodationImage img : images){
-            if(!img.getAccommodation().getId().equals(accommodationId)){
-                throw new IllegalArgumentException("이미지가 해당 숙소에 속하지 않습니다.");
-            }
+        if (images.size() != imageIds.size()){
+            throw new IllegalArgumentException("일부 이미지가 존재하지 않거나 해당 숙소에 속하지 않습니다.");
         }
 
         accommodationImageRepository.deleteAll(images);
 
         return AccommodationImageDeleteResponseDTO.builder()
-                .imageIds(request.getImageIds())
+                .imageIds(imageIds)
                 .message("이미지 삭제 완료")
                 .build();
     }


### PR DESCRIPTION
## 🔗 반영 브랜치

(#12 ) feature/accommodation -> develop

## 📝 작업 내용

- 숙소 수정 및 삭제 관련 엔드포인트 분리 및 서비스 로직 구현
- 숙소 Controller에서 CustomOAuth2User 적용
- Entity PK 필드명 'id'로 통일
- Controller에 javadoc 설명 문구 추가 및 POST 요청 시 응답 코드 201 CREATED로 변경

## 💬 리뷰 요구사항
- 작업이 늦어지다보니 한 커밋과 pr에 다른 변경 사항도 같이 올리게 되었는데, 다음부터는 이런 일이 없도록 정리하면서 올리겠습니다.  죄송합니다..!
- 엔드포인트 관련한 변경사항은 노션에 업데이트 해놨습니다.