### PR TITLE
Feat: 예약 취소 API 구현

### DIFF
--- a/src/main/java/com/project/cozystay/booking/controller/BookingCommandController.java
+++ b/src/main/java/com/project/cozystay/booking/controller/BookingCommandController.java
@@ -4,14 +4,12 @@ import com.project.cozystay.auth.CustomOAuth2User;
 import com.project.cozystay.booking.dto.BookingCreateRequest;
 import com.project.cozystay.booking.dto.BookingResponse;
 import com.project.cozystay.booking.exception.AuthenticationRequiredException;
+import com.project.cozystay.booking.service.BookingCancelCommandService;
 import com.project.cozystay.booking.service.BookingCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -21,6 +19,7 @@ import java.net.URI;
 public class BookingCommandController {
 
     private final BookingCommandService bookingCommandService;
+    private final BookingCancelCommandService bookingCancelCommandService;
 
     @PostMapping
     public ResponseEntity<BookingResponse> createBooking(
@@ -36,5 +35,20 @@ public class BookingCommandController {
         BookingResponse response = bookingCommandService.createBooking(request, guestId);
 
         return ResponseEntity.created(URI.create("/api/bookings/" + response.getBookingId())).body(response);
+    }
+
+    @PatchMapping("/{bookingId}/cancel")
+    public ResponseEntity<Void> cancelBooking(
+            @PathVariable Long bookingId,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ){
+        if(principal == null){
+            throw new AuthenticationRequiredException();
+        }
+
+        Long guestId = principal.getUser().getId();
+        bookingCancelCommandService.cancel(bookingId, guestId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/project/cozystay/booking/controller/BookingCommandController.java
+++ b/src/main/java/com/project/cozystay/booking/controller/BookingCommandController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
-import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/project/cozystay/booking/domain/Booking.java
+++ b/src/main/java/com/project/cozystay/booking/domain/Booking.java
@@ -1,5 +1,7 @@
 package com.project.cozystay.booking.domain;
 
+import com.project.cozystay.booking.exception.BookingAlreadyCancelledException;
+import com.project.cozystay.booking.exception.BookingCancellationNotAllowedException;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -96,7 +98,14 @@ public class Booking {
     }
 
     public void cancel(){
+        if(this.status == BookingStatus.CANCELLED){
+            throw new BookingAlreadyCancelledException(this.id);
+        }
+        if(this.status == BookingStatus.COMPLETED){
+            throw new BookingCancellationNotAllowedException(this.id, this.status);
+        }
         this.status = BookingStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();
     }
+
 }

--- a/src/main/java/com/project/cozystay/booking/exception/BookingAlreadyCancelledException.java
+++ b/src/main/java/com/project/cozystay/booking/exception/BookingAlreadyCancelledException.java
@@ -2,6 +2,6 @@ package com.project.cozystay.booking.exception;
 
 public class BookingAlreadyCancelledException extends RuntimeException{
     public BookingAlreadyCancelledException(Long bookingId){
-        super("이미 취소된 예약입니다. bookingId = " + bookingId);
+        super(String.format("이미 취소된 예약입니다. bookingId = %d", bookingId));
     }
 }

--- a/src/main/java/com/project/cozystay/booking/exception/BookingAlreadyCancelledException.java
+++ b/src/main/java/com/project/cozystay/booking/exception/BookingAlreadyCancelledException.java
@@ -1,0 +1,7 @@
+package com.project.cozystay.booking.exception;
+
+public class BookingAlreadyCancelledException extends RuntimeException{
+    public BookingAlreadyCancelledException(Long bookingId){
+        super("이미 취소된 예약입니다. bookingId = " + bookingId);
+    }
+}

--- a/src/main/java/com/project/cozystay/booking/exception/BookingCancellationNotAllowedException.java
+++ b/src/main/java/com/project/cozystay/booking/exception/BookingCancellationNotAllowedException.java
@@ -1,0 +1,9 @@
+package com.project.cozystay.booking.exception;
+
+import com.project.cozystay.booking.domain.BookingStatus;
+
+public class BookingCancellationNotAllowedException extends RuntimeException{
+    public BookingCancellationNotAllowedException(Long bookingId, BookingStatus status){
+        super("현재 상태에서는 예약 취소가 불가능합니다. bookingId=" + bookingId + ", status=" + status);
+    }
+}

--- a/src/main/java/com/project/cozystay/booking/exception/BookingCancellationNotAllowedException.java
+++ b/src/main/java/com/project/cozystay/booking/exception/BookingCancellationNotAllowedException.java
@@ -4,6 +4,6 @@ import com.project.cozystay.booking.domain.BookingStatus;
 
 public class BookingCancellationNotAllowedException extends RuntimeException{
     public BookingCancellationNotAllowedException(Long bookingId, BookingStatus status){
-        super("현재 상태에서는 예약 취소가 불가능합니다. bookingId=" + bookingId + ", status=" + status);
+        super(String.format("현재 상태에서는 예약 취소가 불가능합니다. bookingId=%d, status=%s", bookingId, status));
     }
 }

--- a/src/main/java/com/project/cozystay/booking/repository/BookingRepository.java
+++ b/src/main/java/com/project/cozystay/booking/repository/BookingRepository.java
@@ -2,7 +2,9 @@ package com.project.cozystay.booking.repository;
 
 import com.project.cozystay.booking.domain.Booking;
 import com.project.cozystay.booking.domain.BookingStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,4 +34,12 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
 
     // 내 예약 상세 (본인 것만)
     Optional<Booking> findByIdAndGuestId(Long bookingId, Long guestId);
+
+    // 예약 취소
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select b " +
+            "from Booking b " +
+            "where b.id = :bookingId and b.guestId = :guestId")
+    Optional<Booking> findByIdAndGuestIdForUpdate(@Param("bookingId")Long bookingId,
+                                                  @Param("guestId")Long guestId);
 }

--- a/src/main/java/com/project/cozystay/booking/repository/BookingRepository.java
+++ b/src/main/java/com/project/cozystay/booking/repository/BookingRepository.java
@@ -37,9 +37,7 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
 
     // 예약 취소
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select b " +
-            "from Booking b " +
-            "where b.id = :bookingId and b.guestId = :guestId")
+    @Query("select b from Booking b where b.id = :bookingId and b.guestId = :guestId")
     Optional<Booking> findByIdAndGuestIdForUpdate(@Param("bookingId")Long bookingId,
                                                   @Param("guestId")Long guestId);
 }

--- a/src/main/java/com/project/cozystay/booking/service/BookingCancelCommandService.java
+++ b/src/main/java/com/project/cozystay/booking/service/BookingCancelCommandService.java
@@ -1,0 +1,23 @@
+package com.project.cozystay.booking.service;
+
+import com.project.cozystay.booking.domain.Booking;
+import com.project.cozystay.booking.exception.BookingNotFoundException;
+import com.project.cozystay.booking.repository.BookingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookingCancelCommandService {
+
+    private final BookingRepository bookingRepository;
+
+    @Transactional
+    public void cancel(Long bookingId, Long guestId){
+        Booking booking = bookingRepository.findByIdAndGuestIdForUpdate(bookingId, guestId)
+                .orElseThrow(() -> new BookingNotFoundException(bookingId));
+
+        booking.cancel();
+    }
+}

--- a/src/main/java/com/project/cozystay/config/SecurityConfig.java
+++ b/src/main/java/com/project/cozystay/config/SecurityConfig.java
@@ -61,8 +61,6 @@ public class SecurityConfig {
 
                         //추가한 부분
                         .requestMatchers(HttpMethod.GET, "/api/accommodations/**").permitAll()
-                        //.requestMatchers(HttpMethod.POST, "/api/bookings/**").permitAll() // TODO: 임시적으로 열어둠
-                        //.requestMatchers(HttpMethod.GET, "/api/bookings/**").permitAll() // TODO : 임시적으로 열어둠
                         .requestMatchers("/error").permitAll() // TODO: 원인 로그를 바로 볼 수 있게 임시적으로
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
@@ -7,8 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
@@ -39,7 +37,7 @@ public class GlobalExceptionHandler {
     }
 
     /* ===================== 409 CONFLICT ===================== */
-    @ExceptionHandler({BookingConflictException.class, BookingNotAvailableException.class})
+    @ExceptionHandler({BookingConflictException.class, BookingNotAvailableException.class, BookingAlreadyCancelledException.class})
     public ResponseEntity<ErrorResponse> handleConflict(RuntimeException e){
         log.warn("Conflict [{}]: {}", e.getClass().getSimpleName(), e.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)

--- a/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
@@ -37,7 +37,8 @@ public class GlobalExceptionHandler {
     }
 
     /* ===================== 409 CONFLICT ===================== */
-    @ExceptionHandler({BookingConflictException.class, BookingNotAvailableException.class, BookingAlreadyCancelledException.class})
+    @ExceptionHandler({BookingConflictException.class, BookingNotAvailableException.class,
+            BookingAlreadyCancelledException.class, BookingCancellationNotAllowedException.class})
     public ResponseEntity<ErrorResponse> handleConflict(RuntimeException e){
         log.warn("Conflict [{}]: {}", e.getClass().getSimpleName(), e.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)


### PR DESCRIPTION
## 🔗 반영 브랜치

(#10) feature/booking -> develop

## 📝 작업 내용

### 예약 취소 API
1. PATCH `/api/bookings/{bookingId}/cancel`
2. JWT 인증 기반으로 본인 예약만 취소 가능
3. DB에 예약 상태를 `CANCELLED`로 수정
4. BookingCommandService 신규 생성 (Command 책임 분리)
5. 동시성 대응 (PESSIMISTIC_WRITE 비관적 락 적용)
6. 테스트
- 정상 취소 시 상태 CANCELLED 변경
<img width="960" height="704" alt="스크린샷 2026-01-05 230059" src="https://github.com/user-attachments/assets/7cfd340f-be71-4cfd-9f74-0f9952176ee9" />
<img width="2233" height="332" alt="스크린샷 2026-01-05 230149" src="https://github.com/user-attachments/assets/f8c3b133-07bb-42ab-9288-71570d0e172a" />

- 이미 취소된 예약 재취소 (409)
<img width="1082" height="560" alt="스크린샷 2026-01-05 230232" src="https://github.com/user-attachments/assets/406d0d10-2ee5-4ea3-9b42-c2ed9942ac45" />


## 💬 리뷰 요구사항
