### PR TITLE
Feat: 즐겨찾기 기능 구현

### DIFF
--- a/src/main/java/com/project/cozystay/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/project/cozystay/favorite/controller/FavoriteController.java
@@ -83,7 +83,7 @@ public class FavoriteController {
     ){
         Long userId = principal.getId();
         favoriteService.deleteFavorite(userId, favoriteId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     /**
@@ -111,6 +111,6 @@ public class FavoriteController {
     ){
         Long userId = principal.getId();
         favoriteService.deleteAccommodation(userId, favoriteId, accommodationId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/project/cozystay/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/project/cozystay/favorite/controller/FavoriteController.java
@@ -1,0 +1,116 @@
+package com.project.cozystay.favorite.controller;
+
+
+import com.project.cozystay.auth.CustomOAuth2User;
+import com.project.cozystay.favorite.dto.FavoriteCreateRequestDTO;
+import com.project.cozystay.favorite.dto.FavoriteDetailResponseDTO;
+import com.project.cozystay.favorite.dto.FavoriteResponseDTO;
+import com.project.cozystay.favorite.dto.FavoriteUpdateRequestDTO;
+import com.project.cozystay.favorite.service.FavoriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/favorites")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    /**
+     * 즐겨찾기 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<FavoriteResponseDTO>> getFavorites(
+            @AuthenticationPrincipal CustomOAuth2User principal) {
+        Long userId = principal.getId();
+        List<FavoriteResponseDTO> response = favoriteService.getFavorites(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 즐겨찾기 생성
+     */
+    @PostMapping
+    public ResponseEntity<Void> createFavorite(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @RequestBody FavoriteCreateRequestDTO request
+    ){
+        Long userId = principal.getId();
+        favoriteService.createFavorite(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
+     * 즐겨찾기 상세 조회
+     */
+    @GetMapping("/{favoriteId}")
+    public ResponseEntity<FavoriteDetailResponseDTO> getFavorite(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @PathVariable Long favoriteId
+    ){
+        Long userId = principal.getId();
+        FavoriteDetailResponseDTO response = favoriteService.getFavoriteDetail(userId, favoriteId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 즐겨찾기 수정
+     */
+    @PatchMapping("/{favoriteId}")
+    public ResponseEntity<Void> updateFavorite(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @PathVariable Long favoriteId,
+            @RequestBody FavoriteUpdateRequestDTO request
+    ) {
+        Long userId = principal.getId();
+        favoriteService.updateFavorite(userId, favoriteId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 즐겨찾기 삭제
+     */
+    @DeleteMapping("/{favoriteId}")
+    public ResponseEntity<Void> deleteFavorite(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @PathVariable Long favoriteId
+    ){
+        Long userId = principal.getId();
+        favoriteService.deleteFavorite(userId, favoriteId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 즐겨찾기 숙소 추가
+     */
+    @PostMapping("/{favoriteId}/accommodations/{accommodationId}")
+    public ResponseEntity<Void> addAccommodation(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @PathVariable Long favoriteId,
+            @PathVariable Long accommodationId
+    ) {
+        Long userId = principal.getId();
+        favoriteService.addAccommodation(userId, favoriteId, accommodationId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
+     * 즐겨찾기 숙소 삭제
+     */
+    @DeleteMapping("/{favoriteId}/accommodations/{accommodationId}")
+    public ResponseEntity<Void> deleteAccommodation(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @PathVariable Long favoriteId,
+            @PathVariable Long accommodationId
+    ){
+        Long userId = principal.getId();
+        favoriteService.deleteAccommodation(userId, favoriteId, accommodationId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/project/cozystay/favorite/domain/Favorite.java
+++ b/src/main/java/com/project/cozystay/favorite/domain/Favorite.java
@@ -40,6 +40,7 @@ public class Favorite {
 
 
     @OneToMany(mappedBy = "favorite", cascade = CascadeType.ALL, orphanRemoval = true)
+    @org.hibernate.annotations.BatchSize(size = 100)
     @Builder.Default
     private List<FavoriteAccommodation> favoriteAccommodations = new ArrayList<>();
 

--- a/src/main/java/com/project/cozystay/favorite/domain/Favorite.java
+++ b/src/main/java/com/project/cozystay/favorite/domain/Favorite.java
@@ -48,8 +48,14 @@ public class Favorite {
     private User user;
 
     public void update(FavoriteUpdateRequestDTO request) {
-        if (request.getName() != null) {this.name = request.getName();}
-        if (request.getDescription() != null) {this.description = request.getDescription();}
-        if (request.getIsPrivate() != null) {this.isPrivate = request.getIsPrivate();}
+        if (request.getName() != null) {
+            this.name = request.getName();
+        }
+        if (request.getDescription() != null) {
+            this.description = request.getDescription();
+        }
+        if (request.getIsPrivate() != null) {
+            this.isPrivate = request.getIsPrivate();
+        }
     }
 }

--- a/src/main/java/com/project/cozystay/favorite/domain/Favorite.java
+++ b/src/main/java/com/project/cozystay/favorite/domain/Favorite.java
@@ -1,0 +1,55 @@
+package com.project.cozystay.favorite.domain;
+
+import com.project.cozystay.favorite.dto.FavoriteUpdateRequestDTO;
+import com.project.cozystay.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "favorites")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "favorite_id")
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column
+    private String description;
+
+    @Column(nullable = false)
+    private boolean isPrivate = false;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+
+    @OneToMany(mappedBy = "favorite", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<FavoriteAccommodation> favoriteAccommodations = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public void update(FavoriteUpdateRequestDTO request) {
+        if (request.getName() != null) {this.name = request.getName();}
+        if (request.getDescription() != null) {this.description = request.getDescription();}
+        if (request.getIsPrivate() != null) {this.isPrivate = request.getIsPrivate();}
+    }
+}

--- a/src/main/java/com/project/cozystay/favorite/domain/FavoriteAccommodation.java
+++ b/src/main/java/com/project/cozystay/favorite/domain/FavoriteAccommodation.java
@@ -1,0 +1,41 @@
+package com.project.cozystay.favorite.domain;
+
+
+import com.project.cozystay.accommodation.domain.Accommodation;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "favorite_accommodations")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteAccommodation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "favorite_accommodation_id")
+    private Long id;
+
+    @CreationTimestamp
+    @Column(name = "added_at", updatable = false)
+    private LocalDateTime addedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "favorite_id", nullable = false)
+    private Favorite favorite;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "accommodation_id", nullable = false)
+    private Accommodation accommodation;
+
+    public static FavoriteAccommodation of(Favorite favorite, Accommodation accommodation) {
+        return FavoriteAccommodation.builder()
+                .favorite(favorite)
+                .accommodation(accommodation)
+                .build();
+    }
+}

--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteAccommodationResponseDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteAccommodationResponseDTO.java
@@ -1,0 +1,38 @@
+package com.project.cozystay.favorite.dto;
+
+import com.project.cozystay.accommodation.domain.Accommodation;
+import com.project.cozystay.accommodation.domain.AccommodationImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class FavoriteAccommodationResponseDTO {
+
+    private Long accommodationId;
+    private String title;
+    private String city;
+    private String country;
+    private BigDecimal pricePerNight;
+    private String imageUrl;
+
+    public static FavoriteAccommodationResponseDTO from(Accommodation accommodation){
+        return FavoriteAccommodationResponseDTO.builder()
+                .accommodationId(accommodation.getId())
+                .title(accommodation.getTitle())
+                .city(accommodation.getCity())
+                .country(accommodation.getCountry())
+                .pricePerNight(accommodation.getPricePerNight())
+                .imageUrl(
+                        accommodation.getImages().stream()
+                                .filter(AccommodationImage::isPrimary) //대표 이미지가 있다면 사용
+                                .findFirst()
+                                .or(() -> accommodation.getImages().stream().findFirst()) //대표 이미지가 없다면 가장 첫 번째 이미지 사용
+                                .map(AccommodationImage::getImageUrl)
+                                .orElse(null)
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteCreateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteCreateRequestDTO.java
@@ -1,0 +1,21 @@
+package com.project.cozystay.favorite.dto;
+
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.favorite.domain.Favorite;
+import lombok.Getter;
+
+@Getter
+public class FavoriteCreateRequestDTO {
+    private String name;
+    private String description;
+    private boolean isPrivate;
+
+    public Favorite toEntity(User user) {
+        return Favorite.builder()
+                .name(name)
+                .description(description)
+                .isPrivate(isPrivate)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteDetailResponseDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteDetailResponseDTO.java
@@ -1,0 +1,33 @@
+package com.project.cozystay.favorite.dto;
+
+import com.project.cozystay.favorite.domain.Favorite;
+import com.project.cozystay.favorite.domain.FavoriteAccommodation;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class FavoriteDetailResponseDTO {
+
+    private Long favoriteId;
+    private String name;
+    private String description;
+    private boolean isPrivate;
+    private List<FavoriteAccommodationResponseDTO> accommodations;
+
+    public static FavoriteDetailResponseDTO from(Favorite favorite) {
+        return FavoriteDetailResponseDTO.builder()
+                .favoriteId(favorite.getId())
+                .name(favorite.getName())
+                .description(favorite.getDescription())
+                .isPrivate(favorite.isPrivate())
+                .accommodations(
+                        favorite.getFavoriteAccommodations().stream()
+                                .map(FavoriteAccommodation::getAccommodation)
+                                .map(FavoriteAccommodationResponseDTO::from)
+                                .toList()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteResponseDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteResponseDTO.java
@@ -1,0 +1,26 @@
+package com.project.cozystay.favorite.dto;
+
+import com.project.cozystay.favorite.domain.Favorite;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FavoriteResponseDTO {
+    private Long favoriteId;
+    private String name;
+    private String description;
+    private boolean isPrivate;
+    private int accommodationCount;
+
+    public static FavoriteResponseDTO from(Favorite favorite){
+        return FavoriteResponseDTO.builder()
+                .favoriteId(favorite.getId())
+                .name(favorite.getName())
+                .description(favorite.getDescription())
+                .isPrivate(favorite.isPrivate())
+                .accommodationCount(favorite.getFavoriteAccommodations().size())
+                .build();
+    }
+}
+

--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteUpdateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteUpdateRequestDTO.java
@@ -1,0 +1,10 @@
+package com.project.cozystay.favorite.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FavoriteUpdateRequestDTO {
+    private String name;
+    private String description;
+    private Boolean isPrivate;
+}

--- a/src/main/java/com/project/cozystay/favorite/repository/FavoriteAccommodationRepository.java
+++ b/src/main/java/com/project/cozystay/favorite/repository/FavoriteAccommodationRepository.java
@@ -1,0 +1,13 @@
+package com.project.cozystay.favorite.repository;
+
+
+import com.project.cozystay.favorite.domain.FavoriteAccommodation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FavoriteAccommodationRepository extends JpaRepository<FavoriteAccommodation, Long> {
+
+    Optional<FavoriteAccommodation> findByFavorite_IdAndAccommodation_Id(Long favoriteId, Long accommodationId);
+
+}

--- a/src/main/java/com/project/cozystay/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/project/cozystay/favorite/repository/FavoriteRepository.java
@@ -2,6 +2,8 @@ package com.project.cozystay.favorite.repository;
 
 import com.project.cozystay.favorite.domain.Favorite;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +13,16 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     List<Favorite> findAllByUser_Id(Long userId);
 
     Optional<Favorite> findByIdAndUser_Id(Long favoriteId, Long userId);
+
+    @Query("""
+            SELECT DISTINCT f
+            FROM Favorite f
+            LEFT JOIN FETCH f.favoriteAccommodations fa
+            LEFT JOIN FETCH fa.accommodation a
+            WHERE f.id = :favoriteId AND f.user.id = :userId
+    """)
+    Optional<Favorite> findDetailByIdAndUserId(
+            @Param("favoriteId")Long favoriteId,
+            @Param("userId") Long userId
+    );
 }

--- a/src/main/java/com/project/cozystay/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/project/cozystay/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,14 @@
+package com.project.cozystay.favorite.repository;
+
+import com.project.cozystay.favorite.domain.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    List<Favorite> findAllByUser_Id(Long userId);
+
+    Optional<Favorite> findByIdAndUser_Id(Long favoriteId, Long userId);
+}

--- a/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
+++ b/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
@@ -69,7 +69,8 @@ public class FavoriteService {
 
     @Transactional(readOnly = true)
     public FavoriteDetailResponseDTO getFavoriteDetail(Long userId, Long favoriteId){
-        Favorite favorite = getOwnedFavorite(userId, favoriteId);
+        Favorite favorite = favoriteRepository.findDetailByIdAndUserId(favoriteId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("즐겨찾기 목록을 찾을 수 없습니다."));
 
         return FavoriteDetailResponseDTO.from(favorite);
     }

--- a/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
+++ b/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
@@ -1,0 +1,99 @@
+package com.project.cozystay.favorite.service;
+
+import com.project.cozystay.accommodation.domain.Accommodation;
+import com.project.cozystay.accommodation.repository.AccommodationRepository;
+import com.project.cozystay.favorite.domain.Favorite;
+import com.project.cozystay.favorite.domain.FavoriteAccommodation;
+import com.project.cozystay.favorite.dto.FavoriteCreateRequestDTO;
+import com.project.cozystay.favorite.dto.FavoriteDetailResponseDTO;
+import com.project.cozystay.favorite.dto.FavoriteResponseDTO;
+import com.project.cozystay.favorite.dto.FavoriteUpdateRequestDTO;
+import com.project.cozystay.favorite.repository.FavoriteAccommodationRepository;
+import com.project.cozystay.favorite.repository.FavoriteRepository;
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final FavoriteAccommodationRepository favoriteAccommodationRepository;
+    private final AccommodationRepository accommodationRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createFavorite(Long userId, FavoriteCreateRequestDTO request) {
+
+        User user = userRepository.getReferenceById(userId);
+
+        Favorite favorite = request.toEntity(user);
+
+        favoriteRepository.save(favorite);
+    }
+
+    @Transactional
+    public void addAccommodation(Long userId, Long favoriteId, Long accommodationId){
+        Favorite favorite = getOwnedFavorite(userId, favoriteId);
+
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("숙소를 찾을 수 없습니다."));
+
+        FavoriteAccommodation favoriteAccommodation = FavoriteAccommodation.of(favorite, accommodation);
+
+        favoriteAccommodationRepository.save(favoriteAccommodation);
+    }
+
+    @Transactional
+    public void deleteAccommodation(Long userId, Long favoriteId, Long accommodationId){
+        getOwnedFavorite(userId, favoriteId);
+
+        FavoriteAccommodation favoriteAccommodation = favoriteAccommodationRepository.findByFavorite_IdAndAccommodation_Id(favoriteId, accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 숙소가 즐겨찾기에 없습니다."));
+
+        favoriteAccommodationRepository.delete(favoriteAccommodation);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FavoriteResponseDTO> getFavorites(Long userId){
+
+        List<Favorite> favorites = favoriteRepository.findAllByUser_Id(userId);
+
+        return favorites.stream().map(FavoriteResponseDTO::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public FavoriteDetailResponseDTO getFavoriteDetail(Long userId, Long favoriteId){
+        Favorite favorite = getOwnedFavorite(userId, favoriteId);
+
+        return FavoriteDetailResponseDTO.from(favorite);
+    }
+
+    @Transactional
+    public void updateFavorite(Long userId, Long favoriteId, FavoriteUpdateRequestDTO request){
+        Favorite favorite = getOwnedFavorite(userId, favoriteId);
+
+        favorite.update(request);
+    }
+
+    @Transactional
+    public void deleteFavorite(Long userId, Long favoriteId){
+        Favorite favorite = getOwnedFavorite(userId, favoriteId);
+
+        favoriteRepository.delete(favorite);
+    }
+
+    /**
+     * 유저가 소유한 즐겨찾기 목록을 조회하는 공통 메서드
+     */
+    private Favorite getOwnedFavorite(Long userId, Long favoriteId){
+        return favoriteRepository.findByIdAndUser_Id(favoriteId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("즐겨찾기 목록을 찾을 수 없습니다."));
+    }
+
+}

--- a/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
+++ b/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
@@ -44,6 +44,11 @@ public class FavoriteService {
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("숙소를 찾을 수 없습니다."));
 
+        //추후 AccommodationStatus.ACTIVE 활용하게 될 경우 추가
+//        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+//                .filter(acc -> acc.getStatus() == AccommodationStatus.ACTIVE)
+//                .orElseThrow(() -> new IllegalArgumentException("활성화된 숙소를 찾을 수 없습니다."));
+
         FavoriteAccommodation favoriteAccommodation = FavoriteAccommodation.of(favorite, accommodation);
 
         favoriteAccommodationRepository.save(favoriteAccommodation);


### PR DESCRIPTION
## 🔗 반영브랜치

(#17 ) feature/favorite -> develop

## 📝 작업 내용

- 즐겨찾기 목록 조회, 생성, 수정, 삭제
- 즐겨찾기 목록에 숙소 추가 및 삭제
- 즐겨찾기 상세 조회

## 즐겨찾기 목록 조회
<img width="817" height="366" alt="스크린샷 2026-01-07 213404" src="https://github.com/user-attachments/assets/a76be0e3-0c22-482a-b89e-f21cf5234575" />

## 즐겨찾기 상세 조회
<img width="600" height="290" alt="스크린샷 2026-01-07 213850" src="https://github.com/user-attachments/assets/ad847501-784b-43c2-8edd-f12a42b50be8" />


## 💬 리뷰 요구사항
- 목록 기능을 추가로 구현하면서 API 앤드포인트가 수정되었습니다! 
- 기존 favorite_accommodation 테이블은 favorite_Id, accommodation_Id 복합키 형태로 구성되어 있었지만 PK를 따로 두는 것이 추후 유지보수에 편할 것 같아서 업데이트 했습니다.
- favorite_accommodation 테이블 변경사항과 API 앤드포인트 변경 사항은 노션에 업데이트 하겠습니다.
