### PR TITLE
Fix : 메인 페이지에서 숙소 조회 시 대표 이미지 반환

### DIFF
--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationResponseDTO.java
@@ -24,7 +24,7 @@ public class AccommodationResponseDTO {
 
         String imageUrl = entity.getImages().stream()
                 .filter(AccommodationImage::isPrimary)
-                .findFirst()
+                .min(Comparator.comparing(AccommodationImage::getId))
                 .or(() -> entity.getImages().stream()
                         .min(Comparator.comparing(AccommodationImage::getId)))
                 .map(AccommodationImage::getImageUrl)

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationResponseDTO.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
-import java.util.List;
+import java.util.Comparator;
 
 @Getter
 @AllArgsConstructor
@@ -17,16 +17,23 @@ public class AccommodationResponseDTO {
 
     private Long accommodationId;
     private String accommodationName;
-    private List<String> accommodationImage;
+    private String accommodationImage;
     private BigDecimal accommodationPrice;
 
     public static AccommodationResponseDTO fromEntity(Accommodation entity) {
+
+        String imageUrl = entity.getImages().stream()
+                .filter(AccommodationImage::isPrimary)
+                .findFirst()
+                .or(() -> entity.getImages().stream()
+                        .min(Comparator.comparing(AccommodationImage::getId)))
+                .map(AccommodationImage::getImageUrl)
+                .orElse(null);
+
         return new AccommodationResponseDTO(
                 entity.getId(),
                 entity.getTitle(),
-                entity.getImages().stream()
-                        .map(AccommodationImage::getImageUrl)
-                        .toList(),
+                imageUrl,
                 entity.getPricePerNight()
         );
     }

--- a/src/main/java/com/project/cozystay/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/com/project/cozystay/accommodation/repository/AccommodationRepository.java
@@ -15,7 +15,7 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
     SELECT DISTINCT a
     FROM Accommodation a
     LEFT JOIN FETCH a.images
-    WHERE a.status = 'ACTIVE'
+    WHERE a.status = com.project.cozystay.accommodation.domain.AccommodationStatus.ACTIVE
 """)
     List<Accommodation> findAllAccommodations();
 

--- a/src/main/java/com/project/cozystay/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/com/project/cozystay/accommodation/repository/AccommodationRepository.java
@@ -15,6 +15,7 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
     SELECT DISTINCT a
     FROM Accommodation a
     LEFT JOIN FETCH a.images
+    WHERE a.status = 'ACTIVE'
 """)
     List<Accommodation> findAllAccommodations();
 


### PR DESCRIPTION
## 🔗 develop

(#24 ) refactor/accommodation -> develop

## 📝 작업 내용
- 메인 페이지에서 숙소 목록 조회 시 대표 이미지가 아닌 숙소 이미지 리스트를 반환하고 있던 부분을 수정
- 메인 페이지에서 활성화 된 숙소(ACTIVE)만 반환하도록 수정

## 💬 리뷰 요구사항
- 메인 페이지에서 숙소 리스트를 조회하면서 이미지를 함께 조회할 때 생기는 성능 문제에 대한 고민을 했습니다. (숙소 CRUD 노션에 정리)
- 현재는 fetch join으로 이미지를 로딩한 뒤, DTO 변환 과정에서 대표 이미지만 선택해 반환하도록 구현했습니다.
