### PR TITLE
Refactor : 즐겨찾기 반환 DTO 추가

### DIFF
--- a/src/main/java/com/project/cozystay/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/project/cozystay/favorite/controller/FavoriteController.java
@@ -2,10 +2,8 @@ package com.project.cozystay.favorite.controller;
 
 
 import com.project.cozystay.auth.CustomOAuth2User;
-import com.project.cozystay.favorite.dto.FavoriteCreateRequestDTO;
-import com.project.cozystay.favorite.dto.FavoriteDetailResponseDTO;
-import com.project.cozystay.favorite.dto.FavoriteResponseDTO;
-import com.project.cozystay.favorite.dto.FavoriteUpdateRequestDTO;
+import com.project.cozystay.favorite.dto.*;
+import com.project.cozystay.favorite.service.FavoriteFacade;
 import com.project.cozystay.favorite.service.FavoriteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +19,7 @@ import java.util.List;
 public class FavoriteController {
 
     private final FavoriteService favoriteService;
+    private final FavoriteFacade favoriteFacade;
 
     /**
      * 즐겨찾기 목록 조회
@@ -37,13 +36,13 @@ public class FavoriteController {
      * 즐겨찾기 생성
      */
     @PostMapping
-    public ResponseEntity<Void> createFavorite(
+    public ResponseEntity<FavoriteCreateResponseDTO> createFavorite(
             @AuthenticationPrincipal CustomOAuth2User principal,
             @RequestBody FavoriteCreateRequestDTO request
     ){
         Long userId = principal.getId();
-        favoriteService.createFavorite(userId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        FavoriteCreateResponseDTO response = favoriteFacade.createFavorite(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     /**

--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteCreateResponseDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteCreateResponseDTO.java
@@ -1,0 +1,10 @@
+package com.project.cozystay.favorite.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class FavoriteCreateResponseDTO {
+    private Long favoriteId;
+}

--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteResponseDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteResponseDTO.java
@@ -1,8 +1,12 @@
 package com.project.cozystay.favorite.dto;
 
+import com.project.cozystay.accommodation.domain.AccommodationImage;
 import com.project.cozystay.favorite.domain.Favorite;
+import com.project.cozystay.favorite.domain.FavoriteAccommodation;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.Optional;
 
 @Getter
 @Builder
@@ -12,15 +16,31 @@ public class FavoriteResponseDTO {
     private String description;
     private boolean isPrivate;
     private int accommodationCount;
+    private String coverImageUrl;
 
-    public static FavoriteResponseDTO from(Favorite favorite){
+    public static FavoriteResponseDTO from(Favorite favorite) {
+        String coverImageUrl = getCoverImageUrl(favorite);
         return FavoriteResponseDTO.builder()
                 .favoriteId(favorite.getId())
                 .name(favorite.getName())
                 .description(favorite.getDescription())
                 .isPrivate(favorite.isPrivate())
                 .accommodationCount(favorite.getFavoriteAccommodations().size())
+                .coverImageUrl(coverImageUrl)
                 .build();
+    }
+
+    private static String getCoverImageUrl(Favorite favorite) {
+        return Optional.ofNullable(favorite.getFavoriteAccommodations())
+                .filter(list -> !list.isEmpty())
+                .map(list -> list.get(0))
+                .map(FavoriteAccommodation::getAccommodation)
+                .flatMap(acc -> acc.getImages().stream()
+                        .filter(AccommodationImage::isPrimary)
+                        .findFirst()
+                        .or(() -> acc.getImages().stream().findFirst())
+                        .map(AccommodationImage::getImageUrl))
+                .orElse(null);
     }
 }
 

--- a/src/main/java/com/project/cozystay/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/project/cozystay/favorite/repository/FavoriteRepository.java
@@ -10,7 +10,15 @@ import java.util.Optional;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
-    List<Favorite> findAllByUser_Id(Long userId);
+    @Query("""
+            SELECT DISTINCT f
+            FROM Favorite f
+            LEFT JOIN FETCH f.favoriteAccommodations fa
+            LEFT JOIN FETCH fa.accommodation a
+            LEFT JOIN FETCH a.images
+            WHERE f.user.id = :userId
+            """)
+    List<Favorite> findAllByUser_Id(@Param("userId") Long userId);
 
     Optional<Favorite> findByIdAndUser_Id(Long favoriteId, Long userId);
 
@@ -19,10 +27,11 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
             FROM Favorite f
             LEFT JOIN FETCH f.favoriteAccommodations fa
             LEFT JOIN FETCH fa.accommodation a
+            LEFT JOIN FETCH a.images
             WHERE f.id = :favoriteId AND f.user.id = :userId
-    """)
+            """)
     Optional<Favorite> findDetailByIdAndUserId(
-            @Param("favoriteId")Long favoriteId,
+            @Param("favoriteId") Long favoriteId,
             @Param("userId") Long userId
     );
 }

--- a/src/main/java/com/project/cozystay/favorite/service/FavoriteFacade.java
+++ b/src/main/java/com/project/cozystay/favorite/service/FavoriteFacade.java
@@ -1,0 +1,30 @@
+package com.project.cozystay.favorite.service;
+
+import com.project.cozystay.accommodation.service.AccommodationService;
+import com.project.cozystay.favorite.domain.Favorite;
+import com.project.cozystay.favorite.dto.FavoriteCreateRequestDTO;
+import com.project.cozystay.favorite.dto.FavoriteCreateResponseDTO;
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FavoriteFacade {
+    private final FavoriteService favoriteService;
+    private final UserService userService;
+    private final AccommodationService accommodationService;
+
+        public FavoriteCreateResponseDTO createFavorite(Long userId, FavoriteCreateRequestDTO request) {
+            User user = userService.getUserRefOrThrow(userId);
+
+            Favorite favorite = request.toEntity(user);
+
+            Long favoriteId = favoriteService.saveFavorite(favorite);
+
+            return FavoriteCreateResponseDTO.builder()
+                    .favoriteId(favoriteId)
+                    .build();
+        }
+    }

--- a/src/main/java/com/project/cozystay/favorite/service/FavoriteFacade.java
+++ b/src/main/java/com/project/cozystay/favorite/service/FavoriteFacade.java
@@ -1,6 +1,5 @@
 package com.project.cozystay.favorite.service;
 
-import com.project.cozystay.accommodation.service.AccommodationService;
 import com.project.cozystay.favorite.domain.Favorite;
 import com.project.cozystay.favorite.dto.FavoriteCreateRequestDTO;
 import com.project.cozystay.favorite.dto.FavoriteCreateResponseDTO;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Component;
 public class FavoriteFacade {
     private final FavoriteService favoriteService;
     private final UserService userService;
-    private final AccommodationService accommodationService;
 
         public FavoriteCreateResponseDTO createFavorite(Long userId, FavoriteCreateRequestDTO request) {
             User user = userService.getUserRefOrThrow(userId);

--- a/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
+++ b/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
@@ -25,17 +25,13 @@ public class FavoriteService {
     private final FavoriteRepository favoriteRepository;
     private final FavoriteAccommodationRepository favoriteAccommodationRepository;
     private final AccommodationRepository accommodationRepository;
-    private final UserRepository userRepository;
 
     @Transactional
-    public void createFavorite(Long userId, FavoriteCreateRequestDTO request) {
-
-        User user = userRepository.getReferenceById(userId);
-
-        Favorite favorite = request.toEntity(user);
-
-        favoriteRepository.save(favorite);
+    public Long saveFavorite(Favorite favorite) {
+        Favorite saved = favoriteRepository.save(favorite);
+        return saved.getId();
     }
+
 
     @Transactional
     public void addAccommodation(Long userId, Long favoriteId, Long accommodationId){

--- a/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
+++ b/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
@@ -4,14 +4,11 @@ import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.repository.AccommodationRepository;
 import com.project.cozystay.favorite.domain.Favorite;
 import com.project.cozystay.favorite.domain.FavoriteAccommodation;
-import com.project.cozystay.favorite.dto.FavoriteCreateRequestDTO;
 import com.project.cozystay.favorite.dto.FavoriteDetailResponseDTO;
 import com.project.cozystay.favorite.dto.FavoriteResponseDTO;
 import com.project.cozystay.favorite.dto.FavoriteUpdateRequestDTO;
 import com.project.cozystay.favorite.repository.FavoriteAccommodationRepository;
 import com.project.cozystay.favorite.repository.FavoriteRepository;
-import com.project.cozystay.user.domain.User;
-import com.project.cozystay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,16 +31,15 @@ public class FavoriteService {
 
 
     @Transactional
-    public void addAccommodation(Long userId, Long favoriteId, Long accommodationId){
+    public void addAccommodation(Long userId, Long favoriteId, Long accommodationId) {
         Favorite favorite = getOwnedFavorite(userId, favoriteId);
+
+        if (favoriteAccommodationRepository.findByFavorite_IdAndAccommodation_Id(favoriteId, accommodationId).isPresent()) {
+            throw new IllegalArgumentException("이미 해당 즐겨찾기에 추가된 숙소입니다.");
+        }
 
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("숙소를 찾을 수 없습니다."));
-
-        //추후 AccommodationStatus.ACTIVE 활용하게 될 경우 추가
-//        Accommodation accommodation = accommodationRepository.findById(accommodationId)
-//                .filter(acc -> acc.getStatus() == AccommodationStatus.ACTIVE)
-//                .orElseThrow(() -> new IllegalArgumentException("활성화된 숙소를 찾을 수 없습니다."));
 
         FavoriteAccommodation favoriteAccommodation = FavoriteAccommodation.of(favorite, accommodation);
 
@@ -61,8 +57,7 @@ public class FavoriteService {
     }
 
     @Transactional(readOnly = true)
-    public List<FavoriteResponseDTO> getFavorites(Long userId){
-
+    public List<FavoriteResponseDTO> getFavorites(Long userId) {
         List<Favorite> favorites = favoriteRepository.findAllByUser_Id(userId);
 
         return favorites.stream().map(FavoriteResponseDTO::from).toList();

--- a/src/main/java/com/project/cozystay/user/service/UserService.java
+++ b/src/main/java/com/project/cozystay/user/service/UserService.java
@@ -23,4 +23,6 @@ public interface UserService {
 
     Map<Long, User> getUsers(List<Long> userIds);
 
+    User getUserRefOrThrow(Long userId);
+
 }

--- a/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
@@ -85,9 +85,20 @@ public class UserServiceImpl implements UserService{
         return PublicUserProfileResponse.from(user);
     }
 
+    /**
+     * 연관관계를 맺고 있는 곳에서 프록시 객체만 얻기 위해 사용 (불필요한 조회 방지)
+     *
+     */
+    @Override
+    public User getUserRefOrThrow(Long userId){
+        if (!userRepository.existsById(userId)) {
+            throw new IllegalArgumentException("사용자를 찾을 수 없습니다. id=" + userId);
+        }
+        return userRepository.getReferenceById(userId);
+    }
 
-    // ======= 내부 공통 메서드 =======
 
+    // ======= 내부 공통 메서드 ======
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. id=" + userId));
@@ -126,7 +137,6 @@ public class UserServiceImpl implements UserService{
                         user -> user
                 ));
     }
-
     /**
      * 내부에서만 쓰는 작은 값 객체
      */

--- a/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
@@ -91,9 +91,6 @@ public class UserServiceImpl implements UserService{
      */
     @Override
     public User getUserRefOrThrow(Long userId){
-        if (!userRepository.existsById(userId)) {
-            throw new IllegalArgumentException("사용자를 찾을 수 없습니다. id=" + userId);
-        }
         return userRepository.getReferenceById(userId);
     }
 

--- a/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
@@ -91,6 +91,7 @@ public class UserServiceImpl implements UserService{
      */
     @Override
     public User getUserRefOrThrow(Long userId){
+
         return userRepository.getReferenceById(userId);
     }
 


### PR DESCRIPTION
## 🔗 반영 브랜치

(#38 ) refactor/favorite -> develop

## 📝 작업 내용

- 즐겨찾기 프론트 작업 중 즐겨찾기 목록 생성 후 ID값을 넘겨주는 것이 좋다고 판단하여 DTO를 추가하였습니다. (기존에는 void)
- 즐겨찾기 로직을 다시 보면서 Facade 패턴을 도입하면 좋을 것 같아 우선 생성 로직에 대해서만 적용했습니다. (추후 다른 로직도 Facade 패턴 내부로 변경 예정)


## 💬 리뷰 요구사항

- 기존에 구현되어있던 UserServiceImpl내에 있는 getUserOrThrow 메서드를 활용하는 방안도 있지만, 해당 메서드는 User 엔티티 전체를 반환하므로 Favorite에서는 사용하지 않고 새롭게 프록시 객체를 반환하는 메서드를 정의했습니다. (User 도메인 전체를 받을 필요는 없다고 생각했기 때문에..)