### PR TITLE
feat: 숙소 상세 조회 응답에 hostNickname, hostProfileImageUrl 추가

### DIFF
--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
@@ -63,57 +63,6 @@ public class AccommodationFullResponseDTO {
     private List<AccommodationImageDTO> images;
     private List<AmenityDTO> amenities;
 
-    public static AccommodationFullResponseDTO fromEntity(Accommodation entity) {
-
-        return AccommodationFullResponseDTO.builder()
-                .accommodationId(entity.getId())
-                .hostId(entity.getHostId())
-                .title(entity.getTitle())
-                .description(entity.getDescription())
-                .accommodationType(entity.getAccommodationType().name())
-                .address(entity.getAddress())
-                .city(entity.getCity())
-                .state(entity.getState())
-                .country(entity.getCountry())
-                .postalCode(entity.getPostalCode())
-                .latitude(entity.getLatitude())
-                .longitude(entity.getLongitude())
-                .maxGuests(entity.getMaxGuests())
-                .pricePerNight(entity.getPricePerNight())
-                .cleaningFee(entity.getCleaningFee())
-                .serviceFeePercentage(entity.getServiceFeePercentage())
-                .instantBooking(entity.getInstantBooking())
-                .checkInTime(entity.getCheckInTime())
-                .checkOutTime(entity.getCheckOutTime())
-
-                .detail(entity.getDetail() != null ?
-                                AccommodationDetailInfoDTO.fromEntity(entity.getDetail())
-                                : null
-                )
-
-                .images(
-                        entity.getImages().stream()
-                                .map(i -> AccommodationImageDTO.builder()
-                                        .imageId(i.getId())
-                                        .imageUrl(i.getImageUrl())
-                                        .displayOrder(i.getDisplayOrder())
-                                        .isPrimary(i.isPrimary())
-                                        .build()
-                                ).toList()
-                )
-                .amenities(
-                        entity.getAmenities().stream()
-                                .map(a -> AmenityDTO.builder()
-                                        .amenityId(a.getAmenity().getId())
-                                        .name(a.getAmenity().getName())
-                                        .icon(a.getAmenity().getIcon())
-                                        .category(a.getAmenity().getCategory())
-                                        .build()
-                                ).toList()
-                )
-                .build();
-    }
-
     public static AccommodationFullResponseDTO fromEntity(
             Accommodation entity,
             String hostNickname,

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
@@ -20,6 +20,10 @@ public class AccommodationFullResponseDTO {
 
     private Long hostId;
 
+    private String hostNickname;
+
+    private String hostProfileImageUrl;
+
     private String title;
 
     private String description;
@@ -87,6 +91,57 @@ public class AccommodationFullResponseDTO {
                                 : null
                 )
 
+                .images(
+                        entity.getImages().stream()
+                                .map(i -> AccommodationImageDTO.builder()
+                                        .imageId(i.getId())
+                                        .imageUrl(i.getImageUrl())
+                                        .displayOrder(i.getDisplayOrder())
+                                        .isPrimary(i.isPrimary())
+                                        .build()
+                                ).toList()
+                )
+                .amenities(
+                        entity.getAmenities().stream()
+                                .map(a -> AmenityDTO.builder()
+                                        .amenityId(a.getAmenity().getId())
+                                        .name(a.getAmenity().getName())
+                                        .icon(a.getAmenity().getIcon())
+                                        .category(a.getAmenity().getCategory())
+                                        .build()
+                                ).toList()
+                )
+                .build();
+    }
+
+    public static AccommodationFullResponseDTO fromEntity(
+            Accommodation entity,
+            String hostNickname,
+            String hostProfileImageUrl
+    ){
+        return AccommodationFullResponseDTO.builder()
+                .accommodationId(entity.getId())
+                .hostId(entity.getHostId())
+                .hostNickname(hostNickname)
+                .hostProfileImageUrl(hostProfileImageUrl)
+                .title(entity.getTitle())
+                .description(entity.getDescription())
+                .accommodationType(entity.getAccommodationType().name())
+                .address(entity.getAddress())
+                .city(entity.getCity())
+                .state(entity.getState())
+                .country(entity.getCountry())
+                .postalCode(entity.getPostalCode())
+                .latitude(entity.getLatitude())
+                .longitude(entity.getLongitude())
+                .maxGuests(entity.getMaxGuests())
+                .pricePerNight(entity.getPricePerNight())
+                .cleaningFee(entity.getCleaningFee())
+                .serviceFeePercentage(entity.getServiceFeePercentage())
+                .instantBooking(entity.getInstantBooking())
+                .checkInTime(entity.getCheckInTime())
+                .checkOutTime(entity.getCheckOutTime())
+                .detail(entity.getDetail() != null ? AccommodationDetailInfoDTO.fromEntity(entity.getDetail()) : null)
                 .images(
                         entity.getImages().stream()
                                 .map(i -> AccommodationImageDTO.builder()

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -7,6 +7,8 @@ import com.project.cozystay.accommodation.repository.AccommodationAmenityReposit
 import com.project.cozystay.accommodation.repository.AccommodationImageRepository;
 import com.project.cozystay.accommodation.repository.AccommodationRepository;
 import com.project.cozystay.accommodation.repository.AmenityRepository;
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ public class AccommodationService {
     private final AccommodationImageRepository accommodationImageRepository;
     private final AccommodationAmenityRepository accommodationAmenityRepository;
     private final AmenityRepository amenityRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public List<AccommodationResponseDTO> getAllAccommodations() {
@@ -46,7 +49,7 @@ public class AccommodationService {
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
 
-       accommodationHostCheck(accommodation, hostId);
+        accommodationHostCheck(accommodation, hostId);
 
         AccommodationDetail detail = request.toEntity();
 
@@ -65,7 +68,14 @@ public class AccommodationService {
         Accommodation accommodation = accommodationRepository.findDetailById(accommodationId)
                 .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다"));
 
-        return AccommodationFullResponseDTO.fromEntity(accommodation);
+        User host = userRepository.findById(accommodation.getHostId())
+                .orElseThrow(()-> new IllegalArgumentException("호스트 유저가 없습니다."));
+
+        return AccommodationFullResponseDTO.fromEntity(
+                accommodation,
+                host.getNickName(),
+                host.getProfileImageUrl()
+        );
     }
 
     @Transactional


### PR DESCRIPTION
## 🔗 반영 브랜치

feature/host-nickname -> develop

## 📝 작업 내용

숙소 상세 조회 API (`/api/accommodation/{id}`) 응답에 호스트 닉네임과 프로필 이미지를 추가했습ㄴ디ㅏ. 

기존에는 hostId만 내려가서 프론트에서 별도 조회가 필요했으나,
API 응답에 hostNickname을 포함하도록 개선했습니다. 

### 주요 변경 사항
- `AccommodationFullResponseDTO`에 `hostNickname`, `hostProfileImageUrl` 필드 추가
- `AccommodationService#getAccommodationDetail`에서 `UserRepository`를 통해 host 조회 후 DTO 매핑
- 프론트에서 하드코딩된 hostName 제거 가능


## 💬 리뷰 요구사항
