### PR TITLE
Feat: Review Summary 구현 - 리뷰 평균, 개수

### DIFF
--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
@@ -63,16 +63,20 @@ public class AccommodationFullResponseDTO {
     private List<AccommodationImageDTO> images;
     private List<AmenityDTO> amenities;
 
+    private ReviewSummaryDTO reviewSummary;
+
     public static AccommodationFullResponseDTO fromEntity(
             Accommodation entity,
             String hostNickname,
-            String hostProfileImageUrl
+            String hostProfileImageUrl,
+            ReviewSummaryDTO reviewSummary
     ){
         return AccommodationFullResponseDTO.builder()
                 .accommodationId(entity.getId())
                 .hostId(entity.getHostId())
                 .hostNickname(hostNickname)
                 .hostProfileImageUrl(hostProfileImageUrl)
+                .reviewSummary(reviewSummary)
                 .title(entity.getTitle())
                 .description(entity.getDescription())
                 .accommodationType(entity.getAccommodationType().name())

--- a/src/main/java/com/project/cozystay/accommodation/dto/ReviewSummaryDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/ReviewSummaryDTO.java
@@ -1,0 +1,12 @@
+package com.project.cozystay.accommodation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReviewSummaryDTO {
+
+    private Double average;
+    private Long count;
+}

--- a/src/main/java/com/project/cozystay/accommodation/dto/ReviewSummaryDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/ReviewSummaryDTO.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ReviewSummaryDTO {
 
-    private Double average;
+    private Number average;
     private Long count;
 }

--- a/src/main/java/com/project/cozystay/accommodation/dto/ReviewSummaryDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/ReviewSummaryDTO.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ReviewSummaryDTO {
 
-    private Number average;
+    private double average;
     private Long count;
 }

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -7,12 +7,14 @@ import com.project.cozystay.accommodation.repository.AccommodationAmenityReposit
 import com.project.cozystay.accommodation.repository.AccommodationImageRepository;
 import com.project.cozystay.accommodation.repository.AccommodationRepository;
 import com.project.cozystay.accommodation.repository.AmenityRepository;
+import com.project.cozystay.review.repository.AccommodationReviewRepository;
 import com.project.cozystay.user.domain.User;
 import com.project.cozystay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +27,7 @@ public class AccommodationService {
     private final AccommodationAmenityRepository accommodationAmenityRepository;
     private final AmenityRepository amenityRepository;
     private final UserRepository userRepository;
+    private final AccommodationReviewRepository accommodationReviewRepository;
 
     @Transactional(readOnly = true)
     public List<AccommodationResponseDTO> getAllAccommodations() {
@@ -71,10 +74,20 @@ public class AccommodationService {
         User host = userRepository.findById(accommodation.getHostId())
                 .orElseThrow(()-> new IllegalArgumentException("호스트 유저가 없습니다."));
 
+        // 리뷰 요약 조회
+        Object[] summary = accommodationReviewRepository.getReviewSummary(accommodationId);
+
+        BigDecimal avgBd = (BigDecimal) summary[0];
+        double average = avgBd.doubleValue();
+        long count = (long) summary[1];
+
+        ReviewSummaryDTO reviewSummary = new ReviewSummaryDTO(average, count);
+
         return AccommodationFullResponseDTO.fromEntity(
                 accommodation,
                 host.getNickName(),
-                host.getProfileImageUrl()
+                host.getProfileImageUrl(),
+                reviewSummary
         );
     }
 

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -11,6 +11,7 @@ import com.project.cozystay.review.repository.AccommodationReviewRepository;
 import com.project.cozystay.user.domain.User;
 import com.project.cozystay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccommodationService {
@@ -75,11 +77,11 @@ public class AccommodationService {
                 .orElseThrow(()-> new IllegalArgumentException("호스트 유저가 없습니다."));
 
         // 리뷰 요약 조회
-        Object[] summary = accommodationReviewRepository.getReviewSummary(accommodationId);
+        Object result = accommodationReviewRepository.getReviewSummary(accommodationId);
+        Object[] row = (Object[]) result;
 
-        BigDecimal avgBd = (BigDecimal) summary[0];
-        double average = avgBd.doubleValue();
-        long count = (long) summary[1];
+        double average = ((Number) row[0]).doubleValue();
+        long count = ((Number) row[1]).longValue();
 
         ReviewSummaryDTO reviewSummary = new ReviewSummaryDTO(average, count);
 

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -77,13 +77,7 @@ public class AccommodationService {
                 .orElseThrow(()-> new IllegalArgumentException("호스트 유저가 없습니다."));
 
         // 리뷰 요약 조회
-        Object result = accommodationReviewRepository.getReviewSummary(accommodationId);
-        Object[] row = (Object[]) result;
-
-        double average = ((Number) row[0]).doubleValue();
-        long count = ((Number) row[1]).longValue();
-
-        ReviewSummaryDTO reviewSummary = new ReviewSummaryDTO(average, count);
+        ReviewSummaryDTO reviewSummary = accommodationReviewRepository.getReviewSummary(accommodationId);
 
         return AccommodationFullResponseDTO.fromEntity(
                 accommodation,

--- a/src/main/java/com/project/cozystay/review/repository/AccommodationReviewRepository.java
+++ b/src/main/java/com/project/cozystay/review/repository/AccommodationReviewRepository.java
@@ -33,5 +33,12 @@ public interface AccommodationReviewRepository extends JpaRepository<Accommodati
             """)
     Optional<AccommodationReview> findByComment_CommentId(@Param("commentId") Long commentId);
 
+    // [0] -> 리뷰 평균 평점, [1] -> 리뷰 개수
+    @Query("""
+        select coalesce(avg(r.ratingOverall), 0), count(r)
+        from AccommodationReview r
+        where r.accommodation.id = :accommodationId
+    """)
+    Object[] getReviewSummary(@Param("accommodationId") Long accommodationId);
 
 }

--- a/src/main/java/com/project/cozystay/review/repository/AccommodationReviewRepository.java
+++ b/src/main/java/com/project/cozystay/review/repository/AccommodationReviewRepository.java
@@ -1,5 +1,6 @@
 package com.project.cozystay.review.repository;
 
+import com.project.cozystay.accommodation.dto.ReviewSummaryDTO;
 import com.project.cozystay.review.domain.AccommodationReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -33,12 +34,12 @@ public interface AccommodationReviewRepository extends JpaRepository<Accommodati
             """)
     Optional<AccommodationReview> findByComment_CommentId(@Param("commentId") Long commentId);
 
-    // [0] -> 리뷰 평균 평점, [1] -> 리뷰 개수
+    // 리뷰 평균, 개수 계산
     @Query("""
-        select coalesce(avg(r.ratingOverall), 0), count(r)
+        select new com.project.cozystay.accommodation.dto.ReviewSummaryDTO(coalesce(avg(r.ratingOverall), 0.0), count(r))
         from AccommodationReview r
         where r.accommodation.id = :accommodationId
     """)
-    Object getReviewSummary(@Param("accommodationId") Long accommodationId);
+    ReviewSummaryDTO getReviewSummary(@Param("accommodationId") Long accommodationId);
 
 }

--- a/src/main/java/com/project/cozystay/review/repository/AccommodationReviewRepository.java
+++ b/src/main/java/com/project/cozystay/review/repository/AccommodationReviewRepository.java
@@ -39,6 +39,6 @@ public interface AccommodationReviewRepository extends JpaRepository<Accommodati
         from AccommodationReview r
         where r.accommodation.id = :accommodationId
     """)
-    Object[] getReviewSummary(@Param("accommodationId") Long accommodationId);
+    Object getReviewSummary(@Param("accommodationId") Long accommodationId);
 
 }


### PR DESCRIPTION
## 🔗 반영 브랜치
 feature/review-summary -> develop

## 📝 작업 내용
- 숙소 상세 조회 API 응답에 다음 정보를 추가했습니다 : reviewSummary(average-평균 평점, count-리뷰 개수)
- 프론트에 숙소 평점과 리뷰 수를 하드코딩하지 않고 API 응답 데이터를 기반으로 표시하기 위해 추가했습니다.


<img width="895" height="659" alt="image" src="https://github.com/user-attachments/assets/f88994f5-325e-4687-85b8-42bf8dff02d0" />


## 💬 리뷰 요구사항

