### PR TITLE
fix: typo in GlobalExceptionHandler

### DIFF
--- a/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
@@ -72,7 +72,7 @@ public class GlobalExceptionHandler {
             BookingGuestDuplicateInvitationException.class, BookingGuestCancelNotAllowedException.class,
             BookingGuestResponseForbiddenException.class, BookingGuestResponseNotAllowedException.class,
             BookingDecisionNotAllowedException.class, ReviewUpdateNotAllowedException.class,
-            InstantBookingDecisionNotAllowedException.class
+            InstantBookingDecisionNotAllowedException.class,
             UserEmailAlreadyExistsException.class, UserNameAlreadyExistsException.class
     })
     public ResponseEntity<ErrorResponse> handleConflict(RuntimeException e){


### PR DESCRIPTION
## 🔗 반영 브랜치

(#) fix/payment-typo -> develop

## 📝 작업 내용
이전 PR에서 충돌 해결 과정 중 `,`가 누락된 것을 확인했습니다. 수정 PR 올렸습니다. <br>
확인 후 먼저 보신 분이 merge해주시면 감사하겠습니다.

## 💬 리뷰 요구사항
