### PR TITLE
 refactor: Payment 도메인 및 컨트롤러 구조 리팩토링

### DIFF
--- a/src/main/java/com/project/cozystay/common/BaseTimeEntity.java
+++ b/src/main/java/com/project/cozystay/common/BaseTimeEntity.java
@@ -16,9 +16,10 @@ import java.time.LocalDateTime;
 public abstract class BaseTimeEntity {
 
     @CreatedDate // 생성 시 시간 자동 저장
-    @Column(updatable = false)
+    @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate // 수정 시 시간 자동 저장
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/project/cozystay/payment/controller/PaymentCommandController.java
+++ b/src/main/java/com/project/cozystay/payment/controller/PaymentCommandController.java
@@ -36,12 +36,7 @@ public class PaymentCommandController {
 
         Payment payment = paymentCommandService.createPayment(bookingId, payerId, method);
 
-        return ResponseEntity.ok(new PaymentCreateResponse(
-                payment.getId(),
-                payment.getStatus(),
-                payment.getPaymentMethod(),
-                payment.getAmount()
-        ));
+        return ResponseEntity.ok(PaymentCreateResponse.from(payment));
     }
 
     // 결제 성공 처리
@@ -62,7 +57,7 @@ public class PaymentCommandController {
                 request.getPaymentKey()
         );
 
-        return ResponseEntity.ok(toResponse(payment));
+        return ResponseEntity.ok(PaymentResponse.from(payment));
     }
 
     // 결제 실패 처리
@@ -77,19 +72,7 @@ public class PaymentCommandController {
 
         Payment payment = paymentCommandService.failPayment(paymentId, payerId);
 
-        return ResponseEntity.ok(toResponse(payment));
+        return ResponseEntity.ok(PaymentResponse.from(payment));
     }
 
-    private PaymentResponse toResponse(Payment payment) {
-        return new PaymentResponse(
-                payment.getId(),
-                payment.getBooking().getId(),
-                payment.getAmount(),
-                payment.getPaymentMethod(),
-                payment.getStatus(),
-                payment.getPaymentKey(),
-                payment.getPaidAt(),
-                payment.getCancelledAt()
-        );
-    }
 }

--- a/src/main/java/com/project/cozystay/payment/controller/PaymentCommandController.java
+++ b/src/main/java/com/project/cozystay/payment/controller/PaymentCommandController.java
@@ -1,7 +1,6 @@
 package com.project.cozystay.payment.controller;
 
 import com.project.cozystay.auth.CustomOAuth2User;
-import com.project.cozystay.booking.exception.AuthenticationRequiredException;
 import com.project.cozystay.payment.domain.Payment;
 import com.project.cozystay.payment.domain.PaymentMethod;
 import com.project.cozystay.payment.dto.PaymentConfirmRequest;
@@ -27,7 +26,6 @@ public class PaymentCommandController {
             @RequestBody PaymentCreateRequest request,
             @AuthenticationPrincipal CustomOAuth2User principal
             ){
-        if(principal == null) throw new AuthenticationRequiredException();
 
         Long payerId = principal.getId();
         Long bookingId = request.getBookingId();
@@ -47,8 +45,6 @@ public class PaymentCommandController {
             @AuthenticationPrincipal CustomOAuth2User principal
             ){
 
-        if(principal == null) throw new AuthenticationRequiredException();
-
         Long payerId = principal.getId();
 
         Payment payment = paymentCommandService.confirmPayment(
@@ -66,8 +62,6 @@ public class PaymentCommandController {
             @PathVariable Long paymentId,
             @AuthenticationPrincipal CustomOAuth2User principal
     ){
-        if(principal == null) throw new AuthenticationRequiredException();
-
         Long payerId = principal.getId();
 
         Payment payment = paymentCommandService.failPayment(paymentId, payerId);

--- a/src/main/java/com/project/cozystay/payment/controller/PaymentQueryController.java
+++ b/src/main/java/com/project/cozystay/payment/controller/PaymentQueryController.java
@@ -31,7 +31,7 @@ public class PaymentQueryController {
         Long requestUserId = principal.getId();
 
         Payment payment = paymentQueryService.getById(paymentId, requestUserId);
-        return ResponseEntity.ok(toResponse(payment));
+        return ResponseEntity.ok(PaymentResponse.from(payment));
     }
 
     // 예약 기준 결제 조회
@@ -45,19 +45,8 @@ public class PaymentQueryController {
         Long requesterUserId = principal.getId();
 
         Payment payment = paymentQueryService.getByBookingId(bookingId, requesterUserId);
-        return ResponseEntity.ok(toResponse(payment));
+        return ResponseEntity.ok(PaymentResponse.from(payment));
     }
 
-    private PaymentResponse toResponse(Payment payment) {
-        return new PaymentResponse(
-                payment.getId(),
-                payment.getBooking().getId(),
-                payment.getAmount(),
-                payment.getPaymentMethod(),
-                payment.getStatus(),
-                payment.getPaymentKey(),
-                payment.getPaidAt(),
-                payment.getCancelledAt()
-        );
-    }
+
 }

--- a/src/main/java/com/project/cozystay/payment/controller/PaymentQueryController.java
+++ b/src/main/java/com/project/cozystay/payment/controller/PaymentQueryController.java
@@ -1,7 +1,6 @@
 package com.project.cozystay.payment.controller;
 
 import com.project.cozystay.auth.CustomOAuth2User;
-import com.project.cozystay.booking.exception.AuthenticationRequiredException;
 import com.project.cozystay.payment.domain.Payment;
 import com.project.cozystay.payment.dto.PaymentResponse;
 import com.project.cozystay.payment.service.PaymentQueryService;
@@ -26,8 +25,6 @@ public class PaymentQueryController {
             @PathVariable Long paymentId,
             @AuthenticationPrincipal CustomOAuth2User principal) {
 
-        if(principal == null) throw new AuthenticationRequiredException();
-
         Long requestUserId = principal.getId();
 
         Payment payment = paymentQueryService.getById(paymentId, requestUserId);
@@ -39,8 +36,6 @@ public class PaymentQueryController {
     public ResponseEntity<PaymentResponse> getPaymentByBooking(
             @PathVariable Long bookingId,
             @AuthenticationPrincipal CustomOAuth2User principal) {
-
-        if(principal == null) throw new AuthenticationRequiredException();
 
         Long requesterUserId = principal.getId();
 

--- a/src/main/java/com/project/cozystay/payment/domain/Payment.java
+++ b/src/main/java/com/project/cozystay/payment/domain/Payment.java
@@ -1,6 +1,7 @@
 package com.project.cozystay.payment.domain;
 
 import com.project.cozystay.booking.domain.Booking;
+import com.project.cozystay.common.BaseTimeEntity;
 import com.project.cozystay.payment.exception.PaymentInvalidStateException;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -21,7 +22,8 @@ import static jakarta.persistence.FetchType.LAZY;
               @UniqueConstraint(name = "uk_payments_payment_key", columnNames = "payment_key")
       }
 )
-public class Payment {
+public class Payment extends BaseTimeEntity{
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "payment_id")
     private Long id;
@@ -54,20 +56,12 @@ public class Payment {
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     private Payment(Booking booking, Long payerId, BigDecimal amount, PaymentMethod paymentMethod){
         this.booking = booking;
         this.payerId = payerId;
         this.amount = amount;
         this.paymentMethod = paymentMethod;
         this.status = PaymentStatus.READY;
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = this.createdAt;
     }
 
     public static Payment create(Booking booking, Long payerId, BigDecimal amount, PaymentMethod paymentMethod){
@@ -81,7 +75,6 @@ public class Payment {
         this.status = PaymentStatus.SUCCESS;
         this.paymentKey = paymentKey;
         this.paidAt = LocalDateTime.now();
-        this.updatedAt = this.paidAt;
     }
 
     public void markFailed(){
@@ -89,7 +82,6 @@ public class Payment {
             throw new PaymentInvalidStateException("결제 실패 처리 불가: status=" + this.status);
         }
         this.status = PaymentStatus.FAILED;
-        this.updatedAt = LocalDateTime.now();
     }
 
     // 환불 & 결제 실패 시 결제 취소 처리
@@ -104,7 +96,6 @@ public class Payment {
 
         this.status = PaymentStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();
-        this.updatedAt = this.cancelledAt;
     }
 
     public void retry(BigDecimal amount, PaymentMethod method){
@@ -122,10 +113,5 @@ public class Payment {
 
         // 다시 결제 시작
         this.status = PaymentStatus.READY;
-
-        // 타임아웃 기준 갱신
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
     }
 }

--- a/src/main/java/com/project/cozystay/payment/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/project/cozystay/payment/dto/PaymentConfirmRequest.java
@@ -1,8 +1,10 @@
 package com.project.cozystay.payment.dto;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 public class PaymentConfirmRequest {
     private String paymentKey;
 }

--- a/src/main/java/com/project/cozystay/payment/dto/PaymentCreateRequest.java
+++ b/src/main/java/com/project/cozystay/payment/dto/PaymentCreateRequest.java
@@ -1,9 +1,11 @@
 package com.project.cozystay.payment.dto;
 
 import com.project.cozystay.payment.domain.PaymentMethod;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 public class PaymentCreateRequest {
     private Long bookingId;
     private PaymentMethod paymentMethod;

--- a/src/main/java/com/project/cozystay/payment/dto/PaymentCreateResponse.java
+++ b/src/main/java/com/project/cozystay/payment/dto/PaymentCreateResponse.java
@@ -4,11 +4,11 @@ import com.project.cozystay.payment.domain.Payment;
 import com.project.cozystay.payment.domain.PaymentMethod;
 import com.project.cozystay.payment.domain.PaymentStatus;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
 import java.math.BigDecimal;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class PaymentCreateResponse {
     private Long paymentId;

--- a/src/main/java/com/project/cozystay/payment/dto/PaymentCreateResponse.java
+++ b/src/main/java/com/project/cozystay/payment/dto/PaymentCreateResponse.java
@@ -1,5 +1,6 @@
 package com.project.cozystay.payment.dto;
 
+import com.project.cozystay.payment.domain.Payment;
 import com.project.cozystay.payment.domain.PaymentMethod;
 import com.project.cozystay.payment.domain.PaymentStatus;
 import lombok.AllArgsConstructor;
@@ -14,4 +15,13 @@ public class PaymentCreateResponse {
     private PaymentStatus paymentStatus;
     private PaymentMethod paymentMethod;
     private BigDecimal amount;
+
+    public static PaymentCreateResponse from(Payment payment) {
+        return new PaymentCreateResponse(
+                payment.getId(),
+                payment.getStatus(),
+                payment.getPaymentMethod(),
+                payment.getAmount()
+        );
+    }
 }

--- a/src/main/java/com/project/cozystay/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/project/cozystay/payment/dto/PaymentResponse.java
@@ -1,5 +1,6 @@
 package com.project.cozystay.payment.dto;
 
+import com.project.cozystay.payment.domain.Payment;
 import com.project.cozystay.payment.domain.PaymentMethod;
 import com.project.cozystay.payment.domain.PaymentStatus;
 import lombok.AllArgsConstructor;
@@ -23,4 +24,17 @@ public class PaymentResponse {
 
     private LocalDateTime paidAt;
     private LocalDateTime cancelledAt;
+
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(
+                payment.getId(),
+                payment.getBooking().getId(),
+                payment.getAmount(),
+                payment.getPaymentMethod(),
+                payment.getStatus(),
+                payment.getPaymentKey(),
+                payment.getPaidAt(),
+                payment.getCancelledAt()
+        );
+    }
 }

--- a/src/main/java/com/project/cozystay/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/project/cozystay/payment/dto/PaymentResponse.java
@@ -4,12 +4,12 @@ import com.project.cozystay.payment.domain.Payment;
 import com.project.cozystay.payment.domain.PaymentMethod;
 import com.project.cozystay.payment.domain.PaymentStatus;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class PaymentResponse {
 

--- a/src/main/java/com/project/cozystay/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/project/cozystay/payment/repository/PaymentRepository.java
@@ -36,8 +36,8 @@ select p
 from Payment p
 join fetch p.booking b
 where p.status = :status
-and p.createdAt < :cutoff
+and p.updatedAt < :cutoff
 """)
     List<Payment> findTimeoutTargetWithBooking(@Param("status")PaymentStatus status,
-                                               @Param("cutoff") LocalDateTime curtoff);
+                                               @Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -39,7 +39,11 @@ public class PaymentCommandService {
             throw new PaymentInvalidStateException("PENDING 예약만 결제 할 수 있습니다. status=" + booking.getStatus());
         }
 
-        BigDecimal amount = calculateAmount(booking);
+        BigDecimal amount = calculateAmount(
+                booking.getCheckInDate(),
+                booking.getCheckOutDate(),
+                booking.getAccommodation().getPricePerNight()
+        );
 
         // 기존 결제 조회
         Payment existing = paymentRepository.findByBooking_Id(bookingId).orElse(null);
@@ -61,16 +65,12 @@ public class PaymentCommandService {
         return paymentRepository.save(payment);
     }
 
-    private BigDecimal calculateAmount(Booking booking) {
-        LocalDate checkIn = booking.getCheckInDate();
-        LocalDate checkOut = booking.getCheckOutDate();
+    private BigDecimal calculateAmount(LocalDate checkIn, LocalDate checkOut, BigDecimal pricePerNight) {
 
         long nights = ChronoUnit.DAYS.between(checkIn, checkOut);
         if(nights <= 0){
             throw new PaymentInvalidStateException("숙박 일수가 올바르지 않습니다. checkIn=" + checkIn + ", checkOut=" + checkOut);
         }
-
-        BigDecimal pricePerNight = booking.getAccommodation().getPricePerNight();
 
         if(pricePerNight == null || pricePerNight.signum() <= 0){
             throw new PaymentInvalidStateException("숙소 가격이 올바르지 않습니다.");


### PR DESCRIPTION
## 🔗 반영 브랜치

refactor/payment -> develop

## 📝 작업 내용
Payment 도메인 관련 코드의 구조를 개선하기 위해 리팩토링을 진행했습니다. 

### 1.  DTO 변환 로직 정리
- Controller 내부의 `toResponse()` 메서드를 제거
- `PaymentResponse.from()` static factory 메서드로 DTO 변환 책임 이동
- Controller → DTO 변환 로직 제거

### 2. Lombok 어노테이션 정리
- Response DTO에서 `@Data` 제거
- 필요한 Lombok만 명시적으로 사용
```
@Data → @Getter + @AllArgsConstructor
@Data → @Getter + @Setter
```
이를 통해 DTO의 불변성 및 의도를 명확히 했습니다.

### 3. BaseTimeEntity 기반 JPA Auditing 적용
- `Payment` 엔티티에 `BaseTimeEntity`적용
- `createdAt`, `updatedAt` 필드 직접 관리 제거
- JPA Auditing을 통한 자동 관리 적용

### 4. 결제 금액 계산 로직 결합도 완화
`calculateAmount()` 메서드에서 `Booking` 엔티티 전체를 전달받던 구조를 수정했습니다.
기존 
```
calculateAmount(Booking booking)
```
변경
```
calculateAmount(LocalDate checkIn, LocalDate checkOut, BigDecimal pricePerNight)
```
이를 통해 Payment 서비스가 Booking 도메인에 직접 의존하는 범위를 줄였습니다.

### 5. Controller 인증 체크 정리
Controller에서 반복되던 인증 체크 제거
```
if(principal == null) throw new AuthenticationRequiredException();
```
변경
- SecurityConfig의 anyRequest().authenticated() 정책에 인증 처리를 위임

### 참고사항
- DTO 변환을 서비스 레이어로 이동하는 리팩토링은 범위가 커질 수 있어 이번 PR에서는 제외했습니다.

## 💬 리뷰 요구사항
