### PR TITLE
Feat: 토스페이먼트 테스트 결제 승인 연동

### DIFF
--- a/src/main/java/com/project/cozystay/CozystayApplication.java
+++ b/src/main/java/com/project/cozystay/CozystayApplication.java
@@ -1,10 +1,13 @@
 package com.project.cozystay;
 
+import com.project.cozystay.payment.config.TossPaymentProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableConfigurationProperties(TossPaymentProperties.class)
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/project/cozystay/payment/config/PaymentHttpConfig.java
+++ b/src/main/java/com/project/cozystay/payment/config/PaymentHttpConfig.java
@@ -1,0 +1,14 @@
+package com.project.cozystay.payment.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class PaymentHttpConfig {
+
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/project/cozystay/payment/config/TossPaymentProperties.java
+++ b/src/main/java/com/project/cozystay/payment/config/TossPaymentProperties.java
@@ -1,0 +1,14 @@
+package com.project.cozystay.payment.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "toss")
+public class TossPaymentProperties {
+    private String clientKey;
+    private String secretKey;
+    private String confirmUrl;
+}

--- a/src/main/java/com/project/cozystay/payment/controller/PaymentCommandController.java
+++ b/src/main/java/com/project/cozystay/payment/controller/PaymentCommandController.java
@@ -38,9 +38,8 @@ public class PaymentCommandController {
     }
 
     // 결제 성공 처리
-    @PostMapping("/{paymentId}/confirm")
+    @PostMapping("confirm")
     public ResponseEntity<PaymentResponse> confirmPayment(
-            @PathVariable Long paymentId,
             @RequestBody PaymentConfirmRequest request,
             @AuthenticationPrincipal CustomOAuth2User principal
             ){
@@ -48,9 +47,10 @@ public class PaymentCommandController {
         Long payerId = principal.getId();
 
         Payment payment = paymentCommandService.confirmPayment(
-                paymentId,
+                request.getOrderId(),
                 payerId,
-                request.getPaymentKey()
+                request.getPaymentKey(),
+                request.getAmount()
         );
 
         return ResponseEntity.ok(PaymentResponse.from(payment));

--- a/src/main/java/com/project/cozystay/payment/domain/Payment.java
+++ b/src/main/java/com/project/cozystay/payment/domain/Payment.java
@@ -19,7 +19,8 @@ import static jakarta.persistence.FetchType.LAZY;
       name = "payments",
       uniqueConstraints ={
               @UniqueConstraint(name = "uk_payments_booking", columnNames = "booking_id"),
-              @UniqueConstraint(name = "uk_payments_payment_key", columnNames = "payment_key")
+              @UniqueConstraint(name = "uk_payments_payment_key", columnNames = "payment_key"),
+              @UniqueConstraint(name = "uk_payments_order_id", columnNames = "order_id")
       }
 )
 public class Payment extends BaseTimeEntity{
@@ -45,6 +46,9 @@ public class Payment extends BaseTimeEntity{
     @Enumerated(EnumType.STRING)
     @Column(name = "payment_status", nullable = false, length = 20)
     private PaymentStatus status;
+
+    @Column(name = "order_id", length = 64, unique = true)
+    private String orderId;
 
     // 실제 PG 연동 시 채워질 값 (지금은 Mock)
     @Column(name= "payment_key", length = 255, unique = true)
@@ -107,11 +111,16 @@ public class Payment extends BaseTimeEntity{
         this.paymentMethod = method;
 
         // 이전 결제 시도 값 초기화
+        this.orderId = null;
         this.paymentKey = null;
         this.paidAt = null;
         this.cancelledAt = null;
 
         // 다시 결제 시작
         this.status = PaymentStatus.READY;
+    }
+
+    public void assignOrderId(String orderId){
+        this.orderId = orderId;
     }
 }

--- a/src/main/java/com/project/cozystay/payment/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/project/cozystay/payment/dto/PaymentConfirmRequest.java
@@ -3,8 +3,12 @@ package com.project.cozystay.payment.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.math.BigDecimal;
+
 @Getter
 @Setter
 public class PaymentConfirmRequest {
     private String paymentKey;
+    private String orderId;
+    private BigDecimal amount;
 }

--- a/src/main/java/com/project/cozystay/payment/dto/PaymentCreateResponse.java
+++ b/src/main/java/com/project/cozystay/payment/dto/PaymentCreateResponse.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 public class PaymentCreateResponse {
     private Long paymentId;
+    private String orderId;
     private PaymentStatus paymentStatus;
     private PaymentMethod paymentMethod;
     private BigDecimal amount;
@@ -19,6 +20,7 @@ public class PaymentCreateResponse {
     public static PaymentCreateResponse from(Payment payment) {
         return new PaymentCreateResponse(
                 payment.getId(),
+                payment.getOrderId(),
                 payment.getStatus(),
                 payment.getPaymentMethod(),
                 payment.getAmount()

--- a/src/main/java/com/project/cozystay/payment/exception/PaymentInvalidStateException.java
+++ b/src/main/java/com/project/cozystay/payment/exception/PaymentInvalidStateException.java
@@ -5,4 +5,8 @@ public class PaymentInvalidStateException extends RuntimeException{
     public PaymentInvalidStateException(String message){
         super(message);
     }
+
+    public PaymentInvalidStateException(String message, Throwable cause){
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/project/cozystay/payment/exception/TossPaymentConfirmException.java
+++ b/src/main/java/com/project/cozystay/payment/exception/TossPaymentConfirmException.java
@@ -1,0 +1,11 @@
+package com.project.cozystay.payment.exception;
+
+public class TossPaymentConfirmException extends RuntimeException {
+    public TossPaymentConfirmException(String message) {
+        super(message);
+    }
+
+    public TossPaymentConfirmException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
+++ b/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
@@ -1,0 +1,48 @@
+package com.project.cozystay.payment.external.toss;
+
+import com.project.cozystay.payment.config.TossPaymentProperties;
+import com.project.cozystay.payment.external.toss.dto.TossConfirmRequest;
+import com.project.cozystay.payment.external.toss.dto.TossConfirmResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+@RequiredArgsConstructor
+public class TossPaymentClient {
+
+    private final TossPaymentProperties tossPaymentProperties;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public TossConfirmResponse confirmPayment(String paymentKey, String orderId, BigDecimal amount) {
+
+        String secretKey = tossPaymentProperties.getSecretKey();
+
+        String encodedKey = Base64.getEncoder()
+                .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Basic " + encodedKey);
+
+        TossConfirmRequest request = new TossConfirmRequest(paymentKey, orderId, amount);
+
+        HttpEntity<TossConfirmRequest> entity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<TossConfirmResponse> response = restTemplate.exchange(
+                tossPaymentProperties.getConfirmUrl(),
+                HttpMethod.POST,
+                entity,
+                TossConfirmResponse.class
+        );
+
+        return response.getBody();
+
+
+    }
+}

--- a/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
+++ b/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
@@ -15,25 +15,36 @@ import java.util.Base64;
 @Component
 @RequiredArgsConstructor
 public class TossPaymentClient {
-
+// 외부 결제사(Toss)와 직접 통신하는 전용 클라이언트
     private final TossPaymentProperties tossPaymentProperties;
+
+    // 외부 HTTP API 호출할 때 쓰는 스프링 클래스
     private final RestTemplate restTemplate = new RestTemplate();
 
+    // 결제 승인 요청 보냄
     public TossConfirmResponse confirmPayment(String paymentKey, String orderId, BigDecimal amount) {
 
+        // Basic Authorization용 인코딩
+        // Authorization: Basic bas64(secretKye:)
         String secretKey = tossPaymentProperties.getSecretKey();
 
         String encodedKey = Base64.getEncoder()
                 .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
 
+        // 헤더 생성
+        // Content-Type : application/json
+        // Authorization: Basic...
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("Authorization", "Basic " + encodedKey);
 
+        // 요청 DTO 생성
         TossConfirmRequest request = new TossConfirmRequest(paymentKey, orderId, amount);
 
+        // HttpEntity로 헤더 + 바디 묶기
         HttpEntity<TossConfirmRequest> entity = new HttpEntity<>(request, headers);
 
+        // 실제 외부 API 호출
         ResponseEntity<TossConfirmResponse> response = restTemplate.exchange(
                 tossPaymentProperties.getConfirmUrl(),
                 HttpMethod.POST,
@@ -41,6 +52,7 @@ public class TossPaymentClient {
                 TossConfirmResponse.class
         );
 
+        // 토스 서버가 준 응답 바디 반환
         return response.getBody();
 
 

--- a/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
+++ b/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
@@ -28,8 +28,8 @@ public class TossPaymentClient {
     // 결제 승인 요청 보냄
     public TossConfirmResponse confirmPayment(String paymentKey, String orderId, BigDecimal amount) {
 
-        log.info("confirmUrl={}", tossPaymentProperties.getConfirmUrl());
-        log.info("secretKey exists={}", tossPaymentProperties.getSecretKey() != null && !tossPaymentProperties.getSecretKey().isBlank());
+        log.debug("confirmUrl={}", tossPaymentProperties.getConfirmUrl());
+        log.debug("secretKey exists={}", tossPaymentProperties.getSecretKey() != null && !tossPaymentProperties.getSecretKey().isBlank());
         // Basic Authorization용 인코딩
         // Authorization: Basic bas64(secretKey:)
         String secretKey = tossPaymentProperties.getSecretKey();

--- a/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
+++ b/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
@@ -5,6 +5,7 @@ import com.project.cozystay.payment.exception.TossPaymentConfirmException;
 import com.project.cozystay.payment.external.toss.dto.TossConfirmRequest;
 import com.project.cozystay.payment.external.toss.dto.TossConfirmResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
@@ -14,6 +15,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TossPaymentClient {
@@ -21,13 +23,15 @@ public class TossPaymentClient {
 
     private final TossPaymentProperties tossPaymentProperties;
     // 외부 HTTP API 호출할 때 쓰는 스프링 클래스
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
     // 결제 승인 요청 보냄
     public TossConfirmResponse confirmPayment(String paymentKey, String orderId, BigDecimal amount) {
 
+        log.info("confirmUrl={}", tossPaymentProperties.getConfirmUrl());
+        log.info("secretKey exists={}", tossPaymentProperties.getSecretKey() != null && !tossPaymentProperties.getSecretKey().isBlank());
         // Basic Authorization용 인코딩
-        // Authorization: Basic bas64(secretKye:)
+        // Authorization: Basic bas64(secretKey:)
         String secretKey = tossPaymentProperties.getSecretKey();
 
         String encodedKey = Base64.getEncoder()
@@ -60,9 +64,5 @@ public class TossPaymentClient {
         }catch (RestClientException e){
             throw new TossPaymentConfirmException("토스 결제 승인 API 호출에 실패했습니다.", e);
         }
-
-
-
-
     }
 }

--- a/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
+++ b/src/main/java/com/project/cozystay/payment/external/toss/TossPaymentClient.java
@@ -1,11 +1,13 @@
 package com.project.cozystay.payment.external.toss;
 
 import com.project.cozystay.payment.config.TossPaymentProperties;
+import com.project.cozystay.payment.exception.TossPaymentConfirmException;
 import com.project.cozystay.payment.external.toss.dto.TossConfirmRequest;
 import com.project.cozystay.payment.external.toss.dto.TossConfirmResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigDecimal;
@@ -16,8 +18,8 @@ import java.util.Base64;
 @RequiredArgsConstructor
 public class TossPaymentClient {
 // 외부 결제사(Toss)와 직접 통신하는 전용 클라이언트
-    private final TossPaymentProperties tossPaymentProperties;
 
+    private final TossPaymentProperties tossPaymentProperties;
     // 외부 HTTP API 호출할 때 쓰는 스프링 클래스
     private final RestTemplate restTemplate = new RestTemplate();
 
@@ -44,16 +46,22 @@ public class TossPaymentClient {
         // HttpEntity로 헤더 + 바디 묶기
         HttpEntity<TossConfirmRequest> entity = new HttpEntity<>(request, headers);
 
-        // 실제 외부 API 호출
-        ResponseEntity<TossConfirmResponse> response = restTemplate.exchange(
-                tossPaymentProperties.getConfirmUrl(),
-                HttpMethod.POST,
-                entity,
-                TossConfirmResponse.class
-        );
+        try{
+            // 실제 외부 API 호출
+            ResponseEntity<TossConfirmResponse> response = restTemplate.exchange(
+                    tossPaymentProperties.getConfirmUrl(),
+                    HttpMethod.POST,
+                    entity,
+                    TossConfirmResponse.class
+            );
 
-        // 토스 서버가 준 응답 바디 반환
-        return response.getBody();
+            // 토스 서버가 준 응답 바디 반환
+            return response.getBody();
+        }catch (RestClientException e){
+            throw new TossPaymentConfirmException("토스 결제 승인 API 호출에 실패했습니다.", e);
+        }
+
+
 
 
     }

--- a/src/main/java/com/project/cozystay/payment/external/toss/dto/TossConfirmRequest.java
+++ b/src/main/java/com/project/cozystay/payment/external/toss/dto/TossConfirmRequest.java
@@ -1,0 +1,14 @@
+package com.project.cozystay.payment.external.toss.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class TossConfirmRequest {
+    private String paymentKey;
+    private String orderId;
+    private BigDecimal amount;
+}

--- a/src/main/java/com/project/cozystay/payment/external/toss/dto/TossConfirmResponse.java
+++ b/src/main/java/com/project/cozystay/payment/external/toss/dto/TossConfirmResponse.java
@@ -1,0 +1,11 @@
+package com.project.cozystay.payment.external.toss.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TossConfirmResponse {
+    private String paymentKey;
+    private String orderId;
+    private String status;
+    private String method;
+}

--- a/src/main/java/com/project/cozystay/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/project/cozystay/payment/repository/PaymentRepository.java
@@ -40,4 +40,15 @@ and p.updatedAt < :cutoff
 """)
     List<Payment> findTimeoutTargetWithBooking(@Param("status")PaymentStatus status,
                                                @Param("cutoff") LocalDateTime cutoff);
+
+    Optional<Payment> findByOrderId(String orderId);
+
+    @Query("""
+select p
+from Payment p
+join fetch p.boking b
+join fetch b.accommodation a
+where p.orderId = :orderId
+""")
+    Optional<Payment> findByOrderIdWithBooking(@Param("orderId")String orderId);
 }

--- a/src/main/java/com/project/cozystay/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/project/cozystay/payment/repository/PaymentRepository.java
@@ -46,7 +46,7 @@ and p.updatedAt < :cutoff
     @Query("""
 select p
 from Payment p
-join fetch p.boking b
+join fetch p.booking b
 join fetch b.accommodation a
 where p.orderId = :orderId
 """)

--- a/src/main/java/com/project/cozystay/payment/scheduler/PaymentTimeoutScheduler.java
+++ b/src/main/java/com/project/cozystay/payment/scheduler/PaymentTimeoutScheduler.java
@@ -24,7 +24,7 @@ public class PaymentTimeoutScheduler {
     @Value("${cozystay.payment.ready-timeout-minutes:15}")
     private long readyTimeoutMinutes;
 
-    // READY 결제 타임아웃 처리 (15분)
+    // READY 결제 타임아웃 처리 (9분)
     // READY 상태가 일정 시간 이상 지속되면 Payment CANCELLED + Booking CANCELLED
     // 1분마다 실행
     @Scheduled(fixedDelay = 60_000)

--- a/src/main/java/com/project/cozystay/payment/scheduler/PaymentTimeoutScheduler.java
+++ b/src/main/java/com/project/cozystay/payment/scheduler/PaymentTimeoutScheduler.java
@@ -21,7 +21,7 @@ public class PaymentTimeoutScheduler {
 
     private final PaymentRepository paymentRepository;
 
-    @Value("${cozystay.payment.ready-timeout-minutes:15}")
+    @Value("${cozystay.payment.ready-timeout-minutes:9}")
     private long readyTimeoutMinutes;
 
     // READY 결제 타임아웃 처리 (9분)

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -84,12 +84,16 @@ public class PaymentCommandService {
 
     // Mock 결제 성공 처리
     @Transactional
-    public Payment confirmPayment(Long paymentId, Long payerId, String paymentKey){
-        Payment payment = paymentRepository.findByIdWithBooking(paymentId)
+    public Payment confirmPayment(String orderId, Long payerId, String paymentKey, BigDecimal amount){
+        Payment payment = paymentRepository.findByOrderIdWithBooking(orderId)
                 .orElseThrow(()-> new PaymentNotFoundException("결제를 찾을 수 없습니다."));
 
         if(!payment.getPayerId().equals(payerId)){
             throw new PaymentInvalidStateException("결제자만 결제 확정 처리를 할 수 있습니다.");
+        }
+
+        if(amount == null || payment.getAmount().compareTo(amount) != 0){
+            throw new PaymentInvalidStateException("결제 금액이 일치하지 않습니다.");
         }
 
         payment.markSuccess(paymentKey);

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -114,7 +114,7 @@ public class PaymentCommandService {
         }catch(TossPaymentConfirmException e){
             log.warn("[PAYMENT CONFIRM FAIL] orderId={}, paymentKey={}, reason={}",
                     orderId, paymentKey, e.getMessage());
-            throw new PaymentInvalidStateException("토스 결제 승인에 실패했습니다.");
+            throw new PaymentInvalidStateException("토스 결제 승인에 실패했습니다.", e);
         }
 
         if(response == null

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -12,6 +12,7 @@ import com.project.cozystay.payment.exception.PaymentInvalidStateException;
 import com.project.cozystay.payment.exception.PaymentNotFoundException;
 import com.project.cozystay.payment.exception.TossPaymentConfirmException;
 import com.project.cozystay.payment.external.toss.TossPaymentClient;
+import com.project.cozystay.payment.external.toss.dto.TossConfirmResponse;
 import com.project.cozystay.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -88,7 +89,7 @@ public class PaymentCommandService {
         return pricePerNight.multiply(BigDecimal.valueOf(nights));
     }
 
-    // Mock 결제 성공 처리
+    // 토스 결제 승인 처리
     @Transactional
     public Payment confirmPayment(String orderId, Long payerId, String paymentKey, BigDecimal amount){
         Payment payment = paymentRepository.findByOrderIdWithBooking(orderId)
@@ -99,7 +100,7 @@ public class PaymentCommandService {
         }
 
         if(payment.getStatus() != PaymentStatus.READY){
-            throw new PaymentInvalidStateException("결제 가능한 샅애가 아닙니다. status=" + payment.getStatus());
+            throw new PaymentInvalidStateException("결제 가능한 상태가 아닙니다. status=" + payment.getStatus());
         }
 
         if(amount == null || payment.getAmount().compareTo(amount) != 0){
@@ -107,12 +108,20 @@ public class PaymentCommandService {
         }
 
         // 토스 승인 API 호출
+        TossConfirmResponse response;
         try{
-            tossPaymentClient.confirmPayment(paymentKey, orderId, amount);
+            response = tossPaymentClient.confirmPayment(paymentKey, orderId, amount);
         }catch(TossPaymentConfirmException e){
             log.warn("[PAYMENT CONFIRM FAIL] orderId={}, paymentKey={}, reason={}",
                     orderId, paymentKey, e.getMessage());
             throw new PaymentInvalidStateException("토스 결제 승인에 실패했습니다.");
+        }
+
+        if(response == null
+                || !"DONE".equals(response.getStatus())
+                || !orderId.equals(response.getOrderId())
+                || !paymentKey.equals(response.getPaymentKey())){
+            throw new PaymentInvalidStateException("유효하지 않은 결제 승인 응답입니다.");
         }
 
         // 승인 성공 시

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -158,6 +158,6 @@ public class PaymentCommandService {
     }
 
     private String generateOrderId() {
-        return "order_" + System.currentTimeMillis() + "_" + java.util.UUID.randomUUID().toString().substring(0, 8);
+        return "order_" + java.util.UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -55,13 +55,16 @@ public class PaymentCommandService {
                 case FAILED, CANCELLED -> {
                     // 기존 결제를 READY로 리셋
                     existing.retry(amount, method);
+                    existing.assignOrderId(generateOrderId());
                     return existing;
                 }
                 default -> throw new PaymentInvalidStateException("처리할 수 없는 결제 상태입니다. status=" + existing.getStatus());
             }
         }
 
+        // 신규 결제 생성
         Payment payment = Payment.create(booking, payerId, amount, method);
+        payment.assignOrderId(generateOrderId());
         return paymentRepository.save(payment);
     }
 
@@ -119,5 +122,9 @@ public class PaymentCommandService {
     @Transactional
     public void refundByBooking(Long bookingId){
         paymentRepository.findByBooking_Id(bookingId).ifPresent(Payment::refund);
+    }
+
+    private String generateOrderId(){
+        return "order_" + System.currentTimeMillis();
     }
 }

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -6,6 +6,7 @@ import com.project.cozystay.booking.exception.BookingNotFoundException;
 import com.project.cozystay.booking.repository.BookingRepository;
 import com.project.cozystay.payment.domain.Payment;
 import com.project.cozystay.payment.domain.PaymentMethod;
+import com.project.cozystay.payment.domain.PaymentStatus;
 import com.project.cozystay.payment.exception.PaymentAlreadyExistsException;
 import com.project.cozystay.payment.exception.PaymentInvalidStateException;
 import com.project.cozystay.payment.exception.PaymentNotFoundException;
@@ -92,6 +93,10 @@ public class PaymentCommandService {
 
         if(!payment.getPayerId().equals(payerId)){
             throw new PaymentInvalidStateException("결제자만 결제 확정 처리를 할 수 있습니다.");
+        }
+
+        if(payment.getStatus() != PaymentStatus.READY){
+            throw new PaymentInvalidStateException("결제 가능한 샅애가 아닙니다. status=" + payment.getStatus());
         }
 
         if(amount == null || payment.getAmount().compareTo(amount) != 0){

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -9,6 +9,7 @@ import com.project.cozystay.payment.domain.PaymentMethod;
 import com.project.cozystay.payment.exception.PaymentAlreadyExistsException;
 import com.project.cozystay.payment.exception.PaymentInvalidStateException;
 import com.project.cozystay.payment.exception.PaymentNotFoundException;
+import com.project.cozystay.payment.external.toss.TossPaymentClient;
 import com.project.cozystay.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ public class PaymentCommandService {
 
     private final BookingRepository bookingRepository;
     private final PaymentRepository paymentRepository;
+    private final TossPaymentClient tossPaymentClient;
 
     // 결제 생성
     @Transactional
@@ -96,6 +98,14 @@ public class PaymentCommandService {
             throw new PaymentInvalidStateException("결제 금액이 일치하지 않습니다.");
         }
 
+        // 토스 승인 API 호출
+        try{
+            tossPaymentClient.confirmPayment(paymentKey, orderId, amount);
+        }catch(Exception e){
+            throw new PaymentInvalidStateException("토스 결제 승인에 실패했습니다.");
+        }
+
+        // 승인 성공 시
         payment.markSuccess(paymentKey);
 
         // instantBooking = true인 경우 -> 결제 성공 시 즉시 예약(CONFIRMED)

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -128,7 +128,7 @@ public class PaymentCommandService {
         paymentRepository.findByBooking_Id(bookingId).ifPresent(Payment::refund);
     }
 
-    private String generateOrderId(){
-        return "order_" + System.currentTimeMillis();
+    private String generateOrderId() {
+        return "order_" + System.currentTimeMillis() + "_" + java.util.UUID.randomUUID().toString().substring(0, 8);
     }
 }

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -58,7 +58,21 @@ public class PaymentCommandService {
         if(existing != null){
             switch(existing.getStatus()){
                 case SUCCESS -> throw new PaymentAlreadyExistsException("이미 결제 완료된 예약입니다.");
-                case READY -> throw new PaymentAlreadyExistsException("이미 결제 진행 중(READY)입니다.");
+
+                case READY -> {
+                    // 이미 생성된 READY 결제를 그대로 재사용
+                    if(existing.getAmount().compareTo(amount) != 0){
+                        throw new PaymentInvalidStateException("기존 결제 금액과 현재 결제 금액이 일치하지 않습니다.");
+                    }
+
+                    if(existing.getPaymentMethod() != method){
+                        existing.retry(amount, method);
+                        existing.assignOrderId(generateOrderId());
+                    }
+
+                    return existing;
+                }
+
                 case FAILED, CANCELLED -> {
                     // 기존 결제를 READY로 리셋
                     existing.retry(amount, method);

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -10,9 +10,11 @@ import com.project.cozystay.payment.domain.PaymentStatus;
 import com.project.cozystay.payment.exception.PaymentAlreadyExistsException;
 import com.project.cozystay.payment.exception.PaymentInvalidStateException;
 import com.project.cozystay.payment.exception.PaymentNotFoundException;
+import com.project.cozystay.payment.exception.TossPaymentConfirmException;
 import com.project.cozystay.payment.external.toss.TossPaymentClient;
 import com.project.cozystay.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentCommandService {
@@ -106,7 +109,9 @@ public class PaymentCommandService {
         // 토스 승인 API 호출
         try{
             tossPaymentClient.confirmPayment(paymentKey, orderId, amount);
-        }catch(Exception e){
+        }catch(TossPaymentConfirmException e){
+            log.warn("[PAYMENT CONFIRM FAIL] orderId={}, paymentKey={}, reason={}",
+                    orderId, paymentKey, e.getMessage());
             throw new PaymentInvalidStateException("토스 결제 승인에 실패했습니다.");
         }
 


### PR DESCRIPTION
## 🔗 반영 브랜치

(#47) feature/payment -> develop

## 📝 작업 내용

Mock 기반으로 구현되어 있던 결제 흐름을 토스페이먼츠 테스트 결제 승인 흐름에 맞게 확장했습니다.

### 주요 변경 사항
- Payment 엔티티에 `orderId` 필드 추가
- 결제 생성 시 `orderId` 생성 및 저장
- 재결제(retry) 시 새로운 `orderId` 재발급
- PaymentRepository에 `orderId` 기준 조회 메서드 추가
- 결제 생성 응답 DTO에 `orderId` 포함
- 결제 승인 요청 DTO를 `paymentKey`, `orderId`, `amount` 기반으로 변경
- 결제 승인 API를 `/api/payments/confirm` 구조로 변경
- 결제 승인 시 `orderId`, `amount`, `payer` 검증 추가
- 토스 결제 승인 API 호출용 `TossPaymentClient` 추가
- 토스 설정값(`secretKey`, `confirmUrl`) 프로퍼티 추가
- RestTemplate을 Bean으로 분리하여 주입 구조로 개선
- 토스 승인 응답 검증 로직 추가
- 결제 타임아웃 기준을 토스 흐름에 맞게 9분으로 조정

### 결제 흐름
- 예약 생성
- 결제 생성 (`READY`, `orderId` 발급)
- 프론트 토스 결제창 호출
- successUrl 진입 후 `/api/payments/confirm` 호출
- 백엔드에서 토스 승인 API 재검증
- 승인 성공 시 Payment `SUCCESS`
- instant booking 숙소는 Booking `CONFIRMED`

## 참고 사항
- 현재는 테스트 결제 연동 단계이며 실제 운영 결제는 아님
- webhook, 취소 API, 부분 환불, PG 추상화는 후속 작업 예정
- failUrl/창 닫기 상황에서는 Payment가 즉시 실패 처리되지 않고 timeout 스케줄러에 의해 정리될 수 있음

## 확인 사항
- [x] 토스 테스트 결제창 오픈 확인
- [x] successUrl → 백엔드 confirm 흐름 확인
- [x] 결제 성공 시 Payment 상태 업데이트 확인
- [x] timeout 설정 9분 반영



## 💬 리뷰 요구사항
