### PR TITLE
Feat : S3 이미지 서버 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ configurations {
 	}
 }
 
+dependencyManagement {
+	imports {
+		mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0"
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -69,6 +75,9 @@ dependencies {
 
 	// Swagger (OpenAPI 3)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+	// AWS S3
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -6,6 +6,7 @@ import com.project.cozystay.accommodation.service.AccommodationService;
 import com.project.cozystay.auth.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -98,11 +99,11 @@ public class AccommodationController {
     public ResponseEntity<AccommodationImageResponseDTO> addImage(
             @PathVariable Long accommodationId,
             @AuthenticationPrincipal CustomOAuth2User principal,
-            @RequestPart("files") List<MultipartFile> files,
-            @RequestPart("metadata") String metadataJson
+            @RequestPart("files") @NotEmpty List<MultipartFile> files,
+            @RequestPart("metadata") @NotEmpty List<AccommodationImageRequestDTO> metadata
     ){
         Long hostId = principal.getId();
-        AccommodationImageResponseDTO response = accommodationImageService.addImage(accommodationId, hostId, files, metadataJson);
+        AccommodationImageResponseDTO response = accommodationImageService.addImage(accommodationId, hostId, files, metadata);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -1,16 +1,18 @@
 package com.project.cozystay.accommodation.controller;
 
-import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.dto.*;
+import com.project.cozystay.accommodation.service.AccommodationImageService;
 import com.project.cozystay.accommodation.service.AccommodationService;
 import com.project.cozystay.auth.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -21,6 +23,7 @@ import java.util.List;
 public class AccommodationController {
 
     private final AccommodationService accommodationService;
+    private final AccommodationImageService accommodationImageService;
 
     /**
      * 숙소 정보 조회 (메인 페이지)
@@ -91,14 +94,15 @@ public class AccommodationController {
      * 숙소 이미지 추가
      */
     @Operation(summary = "숙소 이미지 추가", description = "특정 숙소에 이미지를 추가합니다.")
-    @PostMapping("/images/{accommodationId}")
+    @PostMapping(value = "/images/{accommodationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<AccommodationImageResponseDTO> addImage(
             @PathVariable Long accommodationId,
-            @RequestBody List<AccommodationImageRequestDTO> request,
-            @AuthenticationPrincipal CustomOAuth2User principal
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @RequestPart("files") List<MultipartFile> files,
+            @RequestPart("metadata") String metadataJson
     ){
         Long hostId = principal.getId();
-        AccommodationImageResponseDTO response = accommodationService.addImage(accommodationId, hostId, request);
+        AccommodationImageResponseDTO response = accommodationImageService.addImage(accommodationId, hostId, files, metadataJson);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -173,7 +177,7 @@ public class AccommodationController {
             @AuthenticationPrincipal CustomOAuth2User principal
     ){
         Long hostId = principal.getId();
-        AccommodationImageDeleteResponseDTO response = accommodationService.deleteAccommodationImages(accommodationId, hostId, imageIds);
+        AccommodationImageDeleteResponseDTO response = accommodationImageService.deleteAccommodationImages(accommodationId, hostId, imageIds);
         return ResponseEntity.ok(response);
 
     }

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageRequestDTO.java
@@ -10,13 +10,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AccommodationImageRequestDTO {
-    private String imageUrl;
     private Integer displayOrder;
     private Boolean isPrimary;
 
     public AccommodationImage toEntity() {
         return AccommodationImage.builder()
-                .imageUrl(this.imageUrl)
                 .displayOrder(this.displayOrder)
                 .primary(this.isPrimary != null ? this.isPrimary : false)
                 .build();

--- a/src/main/java/com/project/cozystay/accommodation/repository/AccommodationImageRepository.java
+++ b/src/main/java/com/project/cozystay/accommodation/repository/AccommodationImageRepository.java
@@ -3,6 +3,7 @@ package com.project.cozystay.accommodation.repository;
 import com.project.cozystay.accommodation.domain.AccommodationImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,7 +11,9 @@ public interface AccommodationImageRepository extends JpaRepository <Accommodati
     @Query("""
             SELECT ai
             FROM AccommodationImage ai
-            WHERE ai.id IN :imageids AND ai.accommodation.id = :accommodationId
+            WHERE ai.id IN :imageIds AND ai.accommodation.id = :accommodationId
             """)
-    List<AccommodationImage> findAllByIdInAndAccommodationId(List<Long> imageIds, Long accommodationId);
+    List<AccommodationImage> findAllByIdInAndAccommodationId(
+            @Param("imageIds") List<Long> imageIds,
+            @Param("accommodationId") Long accommodationId);
 }

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
@@ -1,0 +1,121 @@
+package com.project.cozystay.accommodation.service;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.cozystay.accommodation.domain.Accommodation;
+import com.project.cozystay.accommodation.domain.AccommodationImage;
+import com.project.cozystay.accommodation.dto.AccommodationImageDeleteResponseDTO;
+import com.project.cozystay.accommodation.dto.AccommodationImageRequestDTO;
+import com.project.cozystay.accommodation.dto.AccommodationImageResponseDTO;
+import com.project.cozystay.accommodation.repository.AccommodationImageRepository;
+import com.project.cozystay.accommodation.repository.AccommodationRepository;
+import com.project.cozystay.common.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AccommodationImageService {
+    private final AccommodationRepository accommodationRepository;
+    private final AccommodationImageRepository accommodationImageRepository;
+    private final S3Service s3Service;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public AccommodationImageResponseDTO addImage(
+            Long accommodationId,
+            Long hostId,
+            List<MultipartFile> files,
+            String metadataJson) {
+
+        List<AccommodationImageRequestDTO> request;
+        try {
+            request = objectMapper.readValue(
+                    metadataJson,
+                    new TypeReference<List<AccommodationImageRequestDTO>>() {}
+            );
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("metadata JSON 형식이 올바르지 않습니다.", e);
+        }
+
+        if (files == null || files.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+        if (files.size() != request.size()) {
+            throw new IllegalArgumentException("파일 개수와 메타데이터 개수가 일치해야 합니다.");
+        }
+
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+
+        accommodationHostCheck(accommodation, hostId);
+
+        List<AccommodationImage> newImages = new ArrayList<>();
+        for (int i = 0; i < files.size(); i++) {
+            String url = s3Service.uploadFile(files.get(i));
+            AccommodationImageRequestDTO dto = request.get(i);
+            AccommodationImage image = AccommodationImage.builder()
+                    .imageUrl(url)
+                    .displayOrder(dto.getDisplayOrder() != null ? dto.getDisplayOrder() : 0)
+                    .primary(Boolean.TRUE.equals(dto.getIsPrimary()))
+                    .build();
+            accommodation.addImage(image);
+            newImages.add(image);
+        }
+        accommodationRepository.save(accommodation);
+
+        List<Long> imageIds = newImages.stream()
+                .map(AccommodationImage::getId)
+                .toList();
+
+        return AccommodationImageResponseDTO.builder()
+                .message("이미지 등록 완료")
+                .accommodationId(accommodationId)
+                .imageId(imageIds)
+                .build();
+    }
+
+    @Transactional
+    public AccommodationImageDeleteResponseDTO deleteAccommodationImages(
+            Long accommodationId,
+            Long hostId,
+            List<Long> imageIds
+    ) {
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+
+        accommodationHostCheck(accommodation, hostId);
+
+        List<AccommodationImage> images = accommodationImageRepository
+                .findAllByIdInAndAccommodationId(imageIds, accommodationId);
+
+        if (images.size() != imageIds.size()) {
+            throw new IllegalArgumentException("일부 이미지가 존재하지 않거나 해당 숙소에 속하지 않습니다.");
+        }
+
+        for (AccommodationImage image : images) {
+            s3Service.deleteFile(image.getImageUrl());
+        }
+
+        accommodationImageRepository.deleteAll(images);
+
+        return AccommodationImageDeleteResponseDTO.builder()
+                .imageIds(imageIds)
+                .message("이미지 삭제 완료")
+                .build();
+    }
+
+    private void accommodationHostCheck(Accommodation accommodation, Long hostId) {
+        if (!accommodation.getHostId().equals(hostId)) {
+            throw new IllegalStateException("숙소의 소유자만 수정할 수 있습니다.");
+        }
+
+    }
+}

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
@@ -1,8 +1,5 @@
 package com.project.cozystay.accommodation.service;
 
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.domain.AccommodationImage;
@@ -26,28 +23,14 @@ public class AccommodationImageService {
     private final AccommodationRepository accommodationRepository;
     private final AccommodationImageRepository accommodationImageRepository;
     private final S3Service s3Service;
-    private final ObjectMapper objectMapper;
 
     @Transactional
     public AccommodationImageResponseDTO addImage(
             Long accommodationId,
             Long hostId,
             List<MultipartFile> files,
-            String metadataJson) {
+            List<AccommodationImageRequestDTO> request) {
 
-        List<AccommodationImageRequestDTO> request;
-        try {
-            request = objectMapper.readValue(
-                    metadataJson,
-                    new TypeReference<List<AccommodationImageRequestDTO>>() {}
-            );
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("metadata JSON 형식이 올바르지 않습니다.", e);
-        }
-
-        if (files == null || files.isEmpty()) {
-            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
-        }
         if (files.size() != request.size()) {
             throw new IllegalArgumentException("파일 개수와 메타데이터 개수가 일치해야 합니다.");
         }

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -3,8 +3,6 @@ package com.project.cozystay.accommodation.service;
 
 import com.project.cozystay.accommodation.domain.*;
 import com.project.cozystay.accommodation.dto.*;
-import com.project.cozystay.accommodation.repository.AccommodationAmenityRepository;
-import com.project.cozystay.accommodation.repository.AccommodationImageRepository;
 import com.project.cozystay.accommodation.repository.AccommodationRepository;
 import com.project.cozystay.accommodation.repository.AmenityRepository;
 import com.project.cozystay.review.repository.AccommodationReviewRepository;
@@ -15,8 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -25,8 +21,6 @@ import java.util.List;
 public class AccommodationService {
 
     private final AccommodationRepository accommodationRepository;
-    private final AccommodationImageRepository accommodationImageRepository;
-    private final AccommodationAmenityRepository accommodationAmenityRepository;
     private final AmenityRepository amenityRepository;
     private final UserRepository userRepository;
     private final AccommodationReviewRepository accommodationReviewRepository;
@@ -51,8 +45,7 @@ public class AccommodationService {
     @Transactional
     public AccommodationDetailResponseDTO addAccommodationDetail(Long accommodationId, Long hostId, AccommodationDetailRequestDTO request) {
 
-        Accommodation accommodation = accommodationRepository.findById(accommodationId)
-                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+        Accommodation accommodation = getAccommodation(accommodationId);
 
         accommodationHostCheck(accommodation, hostId);
 
@@ -70,8 +63,7 @@ public class AccommodationService {
 
     @Transactional(readOnly = true)
     public AccommodationFullResponseDTO getAccommodationDetail(Long accommodationId) {
-        Accommodation accommodation = accommodationRepository.findDetailById(accommodationId)
-                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다"));
+        Accommodation accommodation = getAccommodation(accommodationId);
 
         User host = userRepository.findById(accommodation.getHostId())
                 .orElseThrow(()-> new IllegalArgumentException("호스트 유저가 없습니다."));
@@ -89,8 +81,7 @@ public class AccommodationService {
 
     @Transactional
     public void publish(Long accommodationId, Long hostId){
-        Accommodation accommodation = accommodationRepository.findDetailById(accommodationId)
-                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+        Accommodation accommodation = getAccommodation(accommodationId);
 
         accommodationHostCheck(accommodation, hostId);
 
@@ -98,37 +89,8 @@ public class AccommodationService {
     }
 
     @Transactional
-    public AccommodationImageResponseDTO addImage(Long accommodationId, Long hostId, List<AccommodationImageRequestDTO> request) {
-        Accommodation accommodation = accommodationRepository.findById(accommodationId)
-                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다"));
-
-        accommodationHostCheck(accommodation, hostId);
-
-        List<AccommodationImage> newImages = new ArrayList<>();
-
-        for (AccommodationImageRequestDTO dto : request) {
-            AccommodationImage image = dto.toEntity();
-            accommodation.addImage(image);
-            newImages.add(image);
-        }
-
-        accommodationRepository.save(accommodation);
-
-        List<Long> imageIds = newImages.stream()
-                .map(AccommodationImage::getId)
-                .toList();
-
-        return AccommodationImageResponseDTO.builder()
-                .message("이미지 등록 완료")
-                .accommodationId(accommodationId)
-                .imageId(imageIds)
-                .build();
-    }
-
-    @Transactional
     public AccommodationAmenityResponseDTO addAmenities(Long accommodationId, Long hostId, List<AccommodationAmenityRequestDTO> request){
-        Accommodation accommodation = accommodationRepository.findById(accommodationId)
-                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다"));
+        Accommodation accommodation = getAccommodation(accommodationId);
 
         accommodationHostCheck(accommodation, hostId);
 
@@ -156,8 +118,7 @@ public class AccommodationService {
     //Cascade 설정에 의해 연관관계를 맺고 있는 테이블도 함께 삭제
     @Transactional
     public AccommodationDeleteResponseDTO deleteAccommodation(Long accommodationId, Long hostId){
-        Accommodation accommodation = accommodationRepository.findById(accommodationId)
-                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다"));
+        Accommodation accommodation = getAccommodation(accommodationId);
 
         accommodationHostCheck(accommodation, hostId);
 
@@ -175,8 +136,7 @@ public class AccommodationService {
             Long hostId,
             AccommodationUpdateRequestDTO request
     ){
-        Accommodation accommodation = accommodationRepository.findById(accommodationId)
-                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+        Accommodation accommodation = getAccommodation(accommodationId);
 
         accommodationHostCheck(accommodation, hostId);
 
@@ -194,8 +154,7 @@ public class AccommodationService {
             Long hostId,
             AccommodationDetailUpdateRequestDTO request
     ){
-        Accommodation accommodation = accommodationRepository.findById(accommodationId)
-                .orElseThrow(()-> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+        Accommodation accommodation = getAccommodation(accommodationId);
 
         accommodationHostCheck(accommodation, hostId);
 
@@ -213,28 +172,6 @@ public class AccommodationService {
                 .build();
     }
 
-    @Transactional
-    public AccommodationImageDeleteResponseDTO deleteAccommodationImages(
-            Long accommodationId, Long hostId, List<Long> imageIds
-    ){
-        Accommodation accommodation = accommodationRepository.findById(accommodationId)
-                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
-
-        accommodationHostCheck(accommodation, hostId);
-
-        List<AccommodationImage> images = accommodationImageRepository.findAllByIdInAndAccommodationId(imageIds, accommodationId);
-
-        if (images.size() != imageIds.size()){
-            throw new IllegalArgumentException("일부 이미지가 존재하지 않거나 해당 숙소에 속하지 않습니다.");
-        }
-
-        accommodationImageRepository.deleteAll(images);
-
-        return AccommodationImageDeleteResponseDTO.builder()
-                .imageIds(imageIds)
-                .message("이미지 삭제 완료")
-                .build();
-    }
 
     /**
      * 숙소의 주인과 요청한 사람이 맞는지 비교하는 공통 메서드
@@ -243,5 +180,10 @@ public class AccommodationService {
         if (!accommodation.getHostId().equals(hostId)){
             throw new IllegalStateException("숙소의 소유자만 수정할 수 있습니다.");
         }
+    }
+
+    private Accommodation getAccommodation(Long accommodationId){
+        return accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
     }
 }

--- a/src/main/java/com/project/cozystay/common/service/S3Service.java
+++ b/src/main/java/com/project/cozystay/common/service/S3Service.java
@@ -1,0 +1,92 @@
+package com.project.cozystay.common.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    public String uploadFile(MultipartFile file) {
+        validateFile(file);
+
+        String originalFilename = file.getOriginalFilename();
+        String fileName = createFileName(originalFilename);
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileName)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(
+                    putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+            );
+
+            return getFileUrl(fileName);
+
+        } catch (IOException e) {
+            throw new RuntimeException("S3 파일 업로드 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    public void deleteFile(String fileUrl){
+        String key = extractKeyFromUrl(fileUrl);
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+
+    public String updateFile(String oldFileUrl, MultipartFile newFile) {
+        deleteFile(oldFileUrl);
+
+        return uploadFile(newFile);
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+    }
+
+    private String createFileName(String originalFilename) {
+        String uuid = UUID.randomUUID().toString();
+
+        if (originalFilename == null || originalFilename.isBlank()) {
+            return uuid;
+        }
+
+        return uuid + "_" + originalFilename;
+    }
+
+    private String getFileUrl(String fileName) {
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
+    }
+
+    private String extractKeyFromUrl(String fileUrl) {
+        return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+    }
+}

--- a/src/main/java/com/project/cozystay/common/service/S3Service.java
+++ b/src/main/java/com/project/cozystay/common/service/S3Service.java
@@ -89,6 +89,11 @@ public class S3Service {
     }
 
     private String extractKeyFromUrl(String fileUrl) {
-        return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+        try {
+            String path = new java.net.URI(fileUrl).getPath();
+            return path.startsWith("/") ? path.substring(1) : path;
+        } catch (java.net.URISyntaxException e) {
+            throw new IllegalArgumentException("잘못된 URL 형식입니다.", e);
+        }
     }
 }

--- a/src/main/java/com/project/cozystay/common/service/S3Service.java
+++ b/src/main/java/com/project/cozystay/common/service/S3Service.java
@@ -83,7 +83,9 @@ public class S3Service {
     }
 
     private String getFileUrl(String fileName) {
-        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
+        return s3Client.utilities()
+                .getUrl(builder -> builder.bucket(bucket).key(fileName))
+                .toString();
     }
 
     private String extractKeyFromUrl(String fileUrl) {


### PR DESCRIPTION
## 🔗 develop

(#50) feature/s3 -> develop

## 📝 작업 내용


<img width="1594" height="524" alt="스크린샷 2026-04-02 205517" src="https://github.com/user-attachments/assets/a46c6002-76da-45b9-8b7d-31c26d580b1b" />


**1. S3 이미지 서버 연동 및 DB 이미지 저장 방식 변경**

 **2. 기존 AccommodationService가 너무 많은 비즈니스 로직 책임을 지고 있어 SRP 측면에서 개선이 필요하다 판단했습니다.
이에 이미지 비즈니스 로직은 AccommodationImageService로 분리했습니다.**

## 💬 리뷰 요구사항

- 기존 이미지 추가 api는 json형태로 url를 직접 받았지만, S3 연동으로 form-data 형식으로 파일과 metadata(text)형태로 받게 되었습니다.
- 로컬 DB와 S3 서버 간 이미지 파일 동기화를 확인하였지만 예외 상황을 대비하여 추가 로직을 보완해야 할 것 같습니다. 

- 분리 과정에서 AccommodationImageService에서 Accommodation 엔티티를 직접 다루는 구조에서 고민했습니다.
- 이미지는 항상 특정 숙소에 종속되는 데이터라고 판단했습니다. 따라서 Accommodation 엔티티를 직접 다루는 구조가 더 자연스럽다 생각하여 비즈니스 로직은 분리하되 Accommodation 엔티티는 직접 다루는 방향으로 설계했습니다.

**2026-04-10 추가사항**
- Controller 매개변수 @ NotEmpty 추가 -> 해당 매개변수가 비어있다면 400에러를 반환. 즉 기존 Service Layer에서 요청에 관한 Null이나 Empty를 검증하는 책임을 컨트롤러에 위임 (하지만 해당 메서드를 다른 Service나 컨트롤러에서 사용한다면 Null이나 Empty를 검증하는 로직을 계속 두는 것이 좋을 것 같습니다.)
- AccommodationService -> AccommodationImageService로 이미지 로직 옮기는 과정에서 발생한 충돌 해결