### PR TITLE
Refactor: 로그인 인증 실패 메시지 통합 및 예외 처리 구조 개선

### DIFF
--- a/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -41,8 +42,8 @@ public class GlobalExceptionHandler {
     }
 
     /* ===================== 401 UNAUTHORIZED ===================== */
-    @ExceptionHandler(AuthenticationRequiredException.class)
-    public ResponseEntity<ErrorResponse> handleAuthRequired(AuthenticationRequiredException e){
+    @ExceptionHandler({AuthenticationRequiredException.class, BadCredentialsException.class})
+    public ResponseEntity<ErrorResponse> handleUnauthorized(Exception e){
         log.warn("Unauthorized [{}]: {}", e.getClass().getSimpleName(), e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse(e.getMessage()));

--- a/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
@@ -12,6 +12,7 @@ import com.project.cozystay.user.exception.UserNameAlreadyExistsException;
 import com.project.cozystay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -63,26 +64,30 @@ public class UserServiceImpl implements UserService{
     @Override
     public SignInResponse signIn(SignInRequest signInRequest) {
 
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(signInRequest.username(), signInRequest.password())
-        );
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(signInRequest.username(), signInRequest.password())
+            );
 
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        User user = userDetails.getUser();
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            User user = userDetails.getUser();
 
-        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
-        String refreshToken = jwtProvider.createRefreshToken(user.getId());
+            String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
+            String refreshToken = jwtProvider.createRefreshToken(user.getId());
 
-        return SignInResponse.builder()
-                .userId(user.getId())
-                .nickName(user.getNickName())
-                .role(user.getUserRole().name())
-                .grantType("Bearer")
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
+            return SignInResponse.builder()
+                    .userId(user.getId())
+                    .nickName(user.getNickName())
+                    .role(user.getUserRole().name())
+                    .grantType("Bearer")
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+        } catch (BadCredentialsException e) {
+            throw new BadCredentialsException("ID 또는 비밀번호가 틀립니다.");
+        }
     }
 
     @Override


### PR DESCRIPTION
## 🔗 반영 브랜치

(#57 ) refactor/login-> develop

## 📝 작업 내용
<img width="451" height="740" alt="image" src="https://github.com/user-attachments/assets/29c3d99f-8da8-4ac7-b0d0-cf7e7155f395" />

<br>

   1. 보안 강화: 로그인 에러 메시지 통합
      - 기존:  단순 500 에러 응답
      - 변경: "ID 또는 비밀번호가 틀립니다."로 메시지 통합 (401 Unauthorized)
      - 사유: 계정 존재 여부를 유추할 수 없도록 하여 무차별 대입 공격(Account Enumeration) 방지

   2. 로직 최적화 (UserServiceImpl)
      - signIn 시 userRepository.findByUsername()으로 유저 존재 여부를 먼저 확인하던 중복 로직 제거
      - AuthenticationManager가 내부적으로 유저 조회와 비밀번호 검증을 한 번에 처리하도록 개선하여 DB 조회 비용 감소

   3. 전역 예외 처리기 정리 (GlobalExceptionHandler)
      - 401(Unauthorized) 관련 핸들러들을 하나로 통합 (AuthenticationRequiredException, BadCredentialsException)
      - 사용하지 않게 된 UserNotFoundException 관련 코드 및 파일 삭제
      - BadCredentialsException 발생 시 커스텀 메시지를 담아 다시 throw 하도록 처리

## 💬 리뷰 요구사항
