### PR TITLE
Fix: 결제 금액에 예약 총액 반영

### DIFF
--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -20,8 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
+
 
 @Slf4j
 @Service
@@ -46,11 +45,7 @@ public class PaymentCommandService {
             throw new PaymentInvalidStateException("PENDING 예약만 결제 할 수 있습니다. status=" + booking.getStatus());
         }
 
-        BigDecimal amount = calculateAmount(
-                booking.getCheckInDate(),
-                booking.getCheckOutDate(),
-                booking.getAccommodation().getPricePerNight()
-        );
+        BigDecimal amount = booking.getTotalPrice();
 
         // 기존 결제 조회
         Payment existing = paymentRepository.findByBooking_Id(bookingId).orElse(null);
@@ -89,20 +84,6 @@ public class PaymentCommandService {
         return paymentRepository.save(payment);
     }
 
-    private BigDecimal calculateAmount(LocalDate checkIn, LocalDate checkOut, BigDecimal pricePerNight) {
-
-        long nights = ChronoUnit.DAYS.between(checkIn, checkOut);
-        if(nights <= 0){
-            throw new PaymentInvalidStateException("숙박 일수가 올바르지 않습니다. checkIn=" + checkIn + ", checkOut=" + checkOut);
-        }
-
-        if(pricePerNight == null || pricePerNight.signum() <= 0){
-            throw new PaymentInvalidStateException("숙소 가격이 올바르지 않습니다.");
-        }
-
-        return pricePerNight.multiply(BigDecimal.valueOf(nights));
-    }
-
     // 토스 결제 승인 처리
     @Transactional
     public Payment confirmPayment(String orderId, Long payerId, String paymentKey, BigDecimal amount){
@@ -122,35 +103,24 @@ public class PaymentCommandService {
         }
 
         // 토스 승인 API 호출
-        TossConfirmResponse response;
+        TossConfirmResponse tossResponse;
         try{
-            response = tossPaymentClient.confirmPayment(paymentKey, orderId, amount);
+            tossResponse = tossPaymentClient.confirmPayment(paymentKey, orderId, amount);
         }catch(TossPaymentConfirmException e){
             log.warn("[PAYMENT CONFIRM FAIL] orderId={}, paymentKey={}, reason={}",
                     orderId, paymentKey, e.getMessage());
-            throw new PaymentInvalidStateException("토스 결제 승인에 실패했습니다.", e);
-        }
-
-        if(response == null
-                || !"DONE".equals(response.getStatus())
-                || !orderId.equals(response.getOrderId())
-                || !paymentKey.equals(response.getPaymentKey())){
-            throw new PaymentInvalidStateException("유효하지 않은 결제 승인 응답입니다.");
+            payment.markFailed();
+            throw e;
         }
 
         // 승인 성공 시
-        payment.markSuccess(paymentKey);
-
-        // instantBooking = true인 경우 -> 결제 성공 시 즉시 예약(CONFIRMED)
-        Booking booking = payment.getBooking();
-        if(Boolean.TRUE.equals(booking.getAccommodation().getInstantBooking())){
-            booking.confirmByHost();
-        }
+        payment.markSuccess(tossResponse.getPaymentKey());
+        payment.getBooking().confirmByHost();
 
         return payment;
     }
 
-    // Mock 결제 실패 처리
+    // 결제 실패 처리
     @Transactional
     public Payment failPayment(Long paymentId, Long payerId){
         Payment payment = paymentRepository.findByIdWithBooking(paymentId)

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -102,15 +102,26 @@ public class PaymentCommandService {
             throw new PaymentInvalidStateException("결제 금액이 일치하지 않습니다.");
         }
 
-        // 토스 승인 API 호출
         TossConfirmResponse tossResponse;
-        try{
-            tossResponse = tossPaymentClient.confirmPayment(paymentKey, orderId, amount);
-        }catch(TossPaymentConfirmException e){
+        // 토스 승인 API 호출
+        try {
+            tossResponse = tossPaymentClient.confirmPayment(
+                    payment.getOrderId(),
+                    paymentKey,
+                    amount
+            );
+        } catch (TossPaymentConfirmException e) {
             log.warn("[PAYMENT CONFIRM FAIL] orderId={}, paymentKey={}, reason={}",
                     orderId, paymentKey, e.getMessage());
             payment.markFailed();
             throw e;
+        }
+
+        if(tossResponse == null
+            || !"DONE".equals(tossResponse.getStatus())
+            || !payment.getOrderId().equals(tossResponse.getOrderId())
+            || !paymentKey.equals(tossResponse.getPaymentKey())){
+            throw new PaymentInvalidStateException("유효하지 않은 결제 승인 응답입니다.");
         }
 
         // 승인 성공 시

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -30,6 +30,7 @@ public class PaymentCommandService {
     private final BookingRepository bookingRepository;
     private final PaymentRepository paymentRepository;
     private final TossPaymentClient tossPaymentClient;
+    private final PaymentFailureService paymentFailureService;
 
     // 결제 생성
     @Transactional
@@ -113,7 +114,7 @@ public class PaymentCommandService {
         } catch (TossPaymentConfirmException e) {
             log.warn("[PAYMENT CONFIRM FAIL] orderId={}, paymentKey={}, reason={}",
                     orderId, paymentKey, e.getMessage());
-            payment.markFailed();
+            paymentFailureService.markFailed(payment.getId());
             throw e;
         }
 

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -106,8 +106,8 @@ public class PaymentCommandService {
         // 토스 승인 API 호출
         try {
             tossResponse = tossPaymentClient.confirmPayment(
-                    payment.getOrderId(),
                     paymentKey,
+                    payment.getOrderId(),
                     amount
             );
         } catch (TossPaymentConfirmException e) {

--- a/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentCommandService.java
@@ -115,7 +115,9 @@ public class PaymentCommandService {
 
         // 승인 성공 시
         payment.markSuccess(tossResponse.getPaymentKey());
-        payment.getBooking().confirmByHost();
+        if(Boolean.TRUE.equals(payment.getBooking().getAccommodation().getInstantBooking())){
+            payment.getBooking().confirmByHost();
+        }
 
         return payment;
     }

--- a/src/main/java/com/project/cozystay/payment/service/PaymentFailureService.java
+++ b/src/main/java/com/project/cozystay/payment/service/PaymentFailureService.java
@@ -1,0 +1,24 @@
+package com.project.cozystay.payment.service;
+
+import com.project.cozystay.payment.domain.Payment;
+import com.project.cozystay.payment.exception.PaymentNotFoundException;
+import com.project.cozystay.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentFailureService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long paymentId){
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new PaymentNotFoundException("결제를 찾을 수 없습니다."));
+
+        payment.markFailed();
+    }
+}


### PR DESCRIPTION
## 🔗 반영 브랜치

(#47 ) feature/payment -> develop

## 📝 작업 내용

- 결제 생성 시 결제 금액을 숙박 요금만 계산하던 로직을 예약 총액 기준으로 변경했습니다.
- 예약 생성 단계에서 계산된 `Booking.totalPrice`를 `Payment.amount`로 사용하도록 수정했습니다.
- 숙박 요금, 청소비, 서비스 수수료가 포함된 금액이 토스 결제창에 전달되도록 했습니다.

## 변경 이유
기존에는 프론트 결제 요약에는 총액이 표시되지만, 백엔드 결제 생성 응답의 `amount`는 숙박 요금만 포함하고 있었습니다.  
프론트는 해당 `amount`를 그대로 토스 결제창에 전달하기 때문에, 토스 결제 페이지에서 숙박 요금만 표시되는 문제가 있었습니다.

## 주요 변경
- `PaymentCommandService#createPayment`
  - 기존: 체크인/체크아웃 날짜와 숙박 단가로 숙박 요금만 재계산
  - 변경: 예약 생성 시 저장된 `booking.getTotalPrice()` 사용

## 테스트
-  `/api/payments` 응답의 `amount`가 예약 총액과 일치하는지 확인
- 토스 결제창에 숙박 요금 + 청소비 + 서비스 수수료 포함 총액이 표시되는지 확인
- 결제 승인 시 금액 불일치 오류가 발생하지 않는지 확인

**[결제 금액 일치 확인]**
<img width="1064" height="695" alt="image" src="https://github.com/user-attachments/assets/ba20ccf2-40ac-4376-b3c8-0c98f578dd70" />




## 💬 리뷰 요구사항
