### PR TITLE
Fix : 즐겨찾기 숙소 중복 조회 버그 수정

### DIFF
--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteAccommodationResponseDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteAccommodationResponseDTO.java
@@ -1,7 +1,6 @@
 package com.project.cozystay.favorite.dto;
 
-import com.project.cozystay.accommodation.domain.Accommodation;
-import com.project.cozystay.accommodation.domain.AccommodationImage;
+import com.project.cozystay.favorite.repository.projection.FavoriteAccommodationProjection;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,23 +19,16 @@ public class FavoriteAccommodationResponseDTO {
     private BigDecimal pricePerNight;
     private String imageUrl;
 
-    public static FavoriteAccommodationResponseDTO from(Accommodation accommodation){
+    public static FavoriteAccommodationResponseDTO from(FavoriteAccommodationProjection projection) {
         return FavoriteAccommodationResponseDTO.builder()
-                .accommodationId(accommodation.getId())
-                .title(accommodation.getTitle())
-                .state(accommodation.getState())
-                .city(accommodation.getCity())
-                .district(accommodation.getDistrict())
-                .country(accommodation.getCountry())
-                .pricePerNight(accommodation.getPricePerNight())
-                .imageUrl(
-                        accommodation.getImages().stream()
-                                .filter(AccommodationImage::isPrimary) //대표 이미지가 있다면 사용
-                                .findFirst()
-                                .or(() -> accommodation.getImages().stream().findFirst()) //대표 이미지가 없다면 가장 첫 번째 이미지 사용
-                                .map(AccommodationImage::getImageUrl)
-                                .orElse(null)
-                )
+                .accommodationId(projection.accommodationId())
+                .title(projection.title())
+                .state(projection.state())
+                .city(projection.city())
+                .district(projection.district())
+                .country(projection.country())
+                .pricePerNight(projection.pricePerNight())
+                .imageUrl(projection.imageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/project/cozystay/favorite/dto/FavoriteDetailResponseDTO.java
+++ b/src/main/java/com/project/cozystay/favorite/dto/FavoriteDetailResponseDTO.java
@@ -1,7 +1,6 @@
 package com.project.cozystay.favorite.dto;
 
 import com.project.cozystay.favorite.domain.Favorite;
-import com.project.cozystay.favorite.domain.FavoriteAccommodation;
 import lombok.*;
 
 import java.util.List;
@@ -16,18 +15,17 @@ public class FavoriteDetailResponseDTO {
     private boolean isPrivate;
     private List<FavoriteAccommodationResponseDTO> accommodations;
 
-    public static FavoriteDetailResponseDTO from(Favorite favorite) {
+    public static FavoriteDetailResponseDTO from(
+            Favorite favorite,
+            List<FavoriteAccommodationResponseDTO> accommodations
+    ) {
         return FavoriteDetailResponseDTO.builder()
                 .favoriteId(favorite.getId())
                 .name(favorite.getName())
                 .description(favorite.getDescription())
                 .isPrivate(favorite.isPrivate())
-                .accommodations(
-                        favorite.getFavoriteAccommodations().stream()
-                                .map(FavoriteAccommodation::getAccommodation)
-                                .map(FavoriteAccommodationResponseDTO::from)
-                                .toList()
-                )
+                .accommodations(accommodations)
                 .build();
     }
+
 }

--- a/src/main/java/com/project/cozystay/favorite/repository/FavoriteAccommodationRepository.java
+++ b/src/main/java/com/project/cozystay/favorite/repository/FavoriteAccommodationRepository.java
@@ -2,12 +2,37 @@ package com.project.cozystay.favorite.repository;
 
 
 import com.project.cozystay.favorite.domain.FavoriteAccommodation;
+import com.project.cozystay.favorite.repository.projection.FavoriteAccommodationProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FavoriteAccommodationRepository extends JpaRepository<FavoriteAccommodation, Long> {
 
     Optional<FavoriteAccommodation> findByFavorite_IdAndAccommodation_Id(Long favoriteId, Long accommodationId);
+
+    @Query("""
+            SELECT new com.project.cozystay.favorite.repository.projection.FavoriteAccommodationProjection(
+                a.id,
+                a.title,
+                a.state,
+                a.city,
+                a.district,
+                a.country,
+                a.pricePerNight,
+                i.imageUrl
+            )
+            FROM FavoriteAccommodation fa
+            JOIN fa.accommodation a
+            LEFT JOIN a.images i ON i.primary = true
+            WHERE fa.favorite.id = :favoriteId
+            ORDER BY fa.addedAt DESC
+            """)
+    List<FavoriteAccommodationProjection> findAccommodationProjectionsByFavoriteId(
+            @Param("favoriteId") Long favoriteId
+    );
 
 }

--- a/src/main/java/com/project/cozystay/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/project/cozystay/favorite/repository/FavoriteRepository.java
@@ -15,23 +15,10 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
             FROM Favorite f
             LEFT JOIN FETCH f.favoriteAccommodations fa
             LEFT JOIN FETCH fa.accommodation a
-            LEFT JOIN FETCH a.images
             WHERE f.user.id = :userId
             """)
     List<Favorite> findAllByUser_Id(@Param("userId") Long userId);
 
     Optional<Favorite> findByIdAndUser_Id(Long favoriteId, Long userId);
 
-    @Query("""
-            SELECT DISTINCT f
-            FROM Favorite f
-            LEFT JOIN FETCH f.favoriteAccommodations fa
-            LEFT JOIN FETCH fa.accommodation a
-            LEFT JOIN FETCH a.images
-            WHERE f.id = :favoriteId AND f.user.id = :userId
-            """)
-    Optional<Favorite> findDetailByIdAndUserId(
-            @Param("favoriteId") Long favoriteId,
-            @Param("userId") Long userId
-    );
 }

--- a/src/main/java/com/project/cozystay/favorite/repository/projection/FavoriteAccommodationProjection.java
+++ b/src/main/java/com/project/cozystay/favorite/repository/projection/FavoriteAccommodationProjection.java
@@ -1,0 +1,15 @@
+package com.project.cozystay.favorite.repository.projection;
+
+import java.math.BigDecimal;
+
+public record FavoriteAccommodationProjection(
+        Long accommodationId,
+        String title,
+        String state,
+        String city,
+        String district,
+        String country,
+        BigDecimal pricePerNight,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
+++ b/src/main/java/com/project/cozystay/favorite/service/FavoriteService.java
@@ -4,6 +4,7 @@ import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.repository.AccommodationRepository;
 import com.project.cozystay.favorite.domain.Favorite;
 import com.project.cozystay.favorite.domain.FavoriteAccommodation;
+import com.project.cozystay.favorite.dto.FavoriteAccommodationResponseDTO;
 import com.project.cozystay.favorite.dto.FavoriteDetailResponseDTO;
 import com.project.cozystay.favorite.dto.FavoriteResponseDTO;
 import com.project.cozystay.favorite.dto.FavoriteUpdateRequestDTO;
@@ -65,10 +66,16 @@ public class FavoriteService {
 
     @Transactional(readOnly = true)
     public FavoriteDetailResponseDTO getFavoriteDetail(Long userId, Long favoriteId){
-        Favorite favorite = favoriteRepository.findDetailByIdAndUserId(favoriteId, userId)
+        Favorite favorite = favoriteRepository.findByIdAndUser_Id(favoriteId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("즐겨찾기 목록을 찾을 수 없습니다."));
 
-        return FavoriteDetailResponseDTO.from(favorite);
+        List<FavoriteAccommodationResponseDTO> accommodations =
+                favoriteAccommodationRepository.findAccommodationProjectionsByFavoriteId(favoriteId)
+                        .stream()
+                        .map(FavoriteAccommodationResponseDTO::from)
+                        .toList();
+
+        return FavoriteDetailResponseDTO.from(favorite, accommodations);
     }
 
     @Transactional


### PR DESCRIPTION
## 🔗반영 브랜치

(#63 ) fix/favorite -> develop


## 📝 작업 내용

<img width="1878" height="870" alt="image" src="https://github.com/user-attachments/assets/ae62ffce-9160-4367-bd3b-ed1a12221660" />

<img width="1903" height="892" alt="image" src="https://github.com/user-attachments/assets/8c1735fc-36bb-4367-894c-864906906128" />

- 즐겨찾기 상세 및 목록 조회 시 이미지 조인으로 인해 숙소가 중복 응답되던 문제 수정
- 즐겨찾기 상세 조회의 숙소 목록을 DTO Projection 기반으로 조회하도록 변경
- Repository 전용 Projection 객체를 추가하여 응답 DTO와 조회 계층의 의존성 분리

## 💬 리뷰 요구사항
