### PR TITLE
Refactor: Elasticsearch 검색 고도화 및 주소 필터링 정확도 개선 작업

### DIFF
--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -6,6 +6,7 @@ import com.project.cozystay.accommodation.service.AccommodationService;
 import com.project.cozystay.auth.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -43,7 +44,7 @@ public class AccommodationController {
     @PostMapping
     public ResponseEntity<AccommodationResponseDTO> createAccommodation(
             @AuthenticationPrincipal CustomOAuth2User principal,
-            @RequestBody AccommodationRequestDTO request
+            @RequestBody @Valid AccommodationRequestDTO request
     ) {
         Long hostId = principal.getId();
         AccommodationResponseDTO response = accommodationService.createAccommodation(request, hostId);
@@ -57,7 +58,7 @@ public class AccommodationController {
     @PostMapping("/details/{accommodationId}")
     public ResponseEntity<AccommodationDetailResponseDTO> addAccommodationDetail(
             @PathVariable Long accommodationId,
-            @RequestBody AccommodationDetailRequestDTO request,
+            @RequestBody @Valid AccommodationDetailRequestDTO request,
             @AuthenticationPrincipal CustomOAuth2User principal
     ) {
         Long hostId = principal.getId();
@@ -143,7 +144,7 @@ public class AccommodationController {
     @PatchMapping("/{accommodationId}")
     public ResponseEntity<AccommodationUpdateResponseDTO> updateAccommodation(
             @PathVariable Long accommodationId,
-            @RequestBody AccommodationUpdateRequestDTO request,
+            @RequestBody @Valid AccommodationUpdateRequestDTO request,
             @AuthenticationPrincipal CustomOAuth2User principal
 
     ){
@@ -159,7 +160,7 @@ public class AccommodationController {
     @PatchMapping("/{accommodationId}/details")
     public ResponseEntity<AccommodationDetailUpdateResponseDTO> updateAccommodationDetail(
             @PathVariable Long accommodationId,
-            @RequestBody AccommodationDetailUpdateRequestDTO request,
+            @RequestBody @Valid AccommodationDetailUpdateRequestDTO request,
             @AuthenticationPrincipal CustomOAuth2User principal
     ){
         Long hostId = principal.getId();

--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -22,6 +22,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/accommodations")
+@org.springframework.validation.annotation.Validated
 public class AccommodationController {
 
     private final AccommodationService accommodationService;
@@ -100,8 +101,8 @@ public class AccommodationController {
     public ResponseEntity<AccommodationImageResponseDTO> addImage(
             @PathVariable Long accommodationId,
             @AuthenticationPrincipal CustomOAuth2User principal,
-            @RequestPart("files") @NotEmpty List<MultipartFile> files,
-            @RequestPart("metadata") @NotEmpty List<AccommodationImageRequestDTO> metadata
+            @RequestPart("files") @NotEmpty(message = "이미지 파일은 최소 1개 이상이어야 합니다.") List<MultipartFile> files,
+            @RequestPart("metadata") @NotEmpty(message = "이미지 메타데이터는 필수입니다.") List<@Valid AccommodationImageRequestDTO> metadata
     ){
         Long hostId = principal.getId();
         AccommodationImageResponseDTO response = accommodationImageService.addImage(accommodationId, hostId, files, metadata);
@@ -115,7 +116,7 @@ public class AccommodationController {
     @PostMapping("/amenities/{accommodationId}")
     public ResponseEntity<AccommodationAmenityResponseDTO> addAmenities(
             @PathVariable Long accommodationId,
-            @RequestBody List<AccommodationAmenityRequestDTO> request,
+            @RequestBody @NotEmpty(message = "편의시설 목록은 비어있을 수 없습니다.") List<@Valid AccommodationAmenityRequestDTO> request,
             @AuthenticationPrincipal CustomOAuth2User principal
     ){
         Long hostId = principal.getId();
@@ -191,7 +192,7 @@ public class AccommodationController {
     @PostMapping("/{accommodationId}/image-categories")
     public ResponseEntity<AccommodationImageCategoryResponseDTO> createImageCategory(
             @PathVariable Long accommodationId,
-            @RequestBody AccommodationImageCategoryRequestDTO request,
+            @RequestBody @Valid AccommodationImageCategoryRequestDTO request,
             @AuthenticationPrincipal CustomOAuth2User principal
     ){
         Long hostId = principal.getId();

--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,7 +23,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/accommodations")
-@org.springframework.validation.annotation.Validated
+@Validated
 public class AccommodationController {
 
     private final AccommodationService accommodationService;

--- a/src/main/java/com/project/cozystay/accommodation/domain/Accommodation.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/Accommodation.java
@@ -189,8 +189,8 @@ public class Accommodation {
                 .pricePerNight(request.pricePerNight())
                 .cleaningFee(request.cleaningFee() != null ? request.cleaningFee() : BigDecimal.ZERO)
                 .instantBooking(request.instantBooking() != null ? request.instantBooking() : false)
-                .checkInTime(request.checkInTime())
-                .checkOutTime(request.checkOutTime())
+                .checkInTime(request.checkInTime() != null ? request.checkInTime() : LocalTime.of(15, 0))
+                .checkOutTime(request.checkOutTime() != null ? request.checkOutTime() : LocalTime.of(11, 0))
                 .status(AccommodationStatus.DRAFT)
                 .build();
     }

--- a/src/main/java/com/project/cozystay/accommodation/domain/Accommodation.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/Accommodation.java
@@ -145,9 +145,6 @@ public class Accommodation {
     //  if (this.images.isEmpty())
     //      throw new IllegalStateException("이미지가 없습니다.");
 
-        if (this.amenities.isEmpty())
-            throw new IllegalStateException("편의시설 정보가 없습니다.");
-
         this.status = AccommodationStatus.ACTIVE;
     }
 

--- a/src/main/java/com/project/cozystay/accommodation/domain/AccommodationDetail.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/AccommodationDetail.java
@@ -55,15 +55,19 @@ public class AccommodationDetail {
     private int dryerCount;
 
     @Column(name = "wifi_available")
+    @Builder.Default
     private boolean wifiAvailable = false;
 
     @Column(name = "parking_available")
+    @Builder.Default
     private boolean parkingAvailable = false;
 
     @Column(name = "pet_available")
+    @Builder.Default
     private boolean petAvailable = false;
 
     @Column(name = "kitchen_available")
+    @Builder.Default
     private boolean kitchenAvailable = false;
 
     void assignAccommodation(Accommodation accommodation){

--- a/src/main/java/com/project/cozystay/accommodation/domain/AccommodationImage.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/AccommodationImage.java
@@ -32,6 +32,7 @@ public class AccommodationImage {
     private String imageUrl;
 
     @Column(name = "is_primary")
+    @Builder.Default
     private boolean  primary = false;
 
     private Integer displayOrder;

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationAmenityRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationAmenityRequestDTO.java
@@ -1,6 +1,9 @@
 package com.project.cozystay.accommodation.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record AccommodationAmenityRequestDTO(
+        @NotBlank(message = "편의시설 이름은 필수입니다.")
         String name,
         String icon,
         String category

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDetailRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDetailRequestDTO.java
@@ -1,17 +1,39 @@
 package com.project.cozystay.accommodation.dto;
 
+import jakarta.validation.constraints.Min;
+
 public record AccommodationDetailRequestDTO(
 
+        @Min(value = 0, message = "방 개수는 0개 이상이어야 합니다.")
         Integer roomCount,
+
+        @Min(value = 0, message = "침실 개수는 0개 이상이어야 합니다.")
         Integer bedroomCount,
+
+        @Min(value = 0, message = "침대 개수는 0개 이상이어야 합니다.")
         Integer bedCount,
+
+        @Min(value = 0, message = "욕실 개수는 0개 이상이어야 합니다.")
         Integer bathroomCount,
+
+        @Min(value = 0, message = "에어컨 개수는 0개 이상이어야 합니다.")
         Integer airConditionerCount,
+
+        @Min(value = 0, message = "헤어드라이어 개수는 0개 이상이어야 합니다.")
         Integer hairDryerCount,
+
+        @Min(value = 0, message = "냉장고 개수는 0개 이상이어야 합니다.")
         Integer refrigeratorCount,
+
+        @Min(value = 0, message = "TV 개수는 0개 이상이어야 합니다.")
         Integer televisionCount,
+
+        @Min(value = 0, message = "세탁기 개수는 0개 이상이어야 합니다.")
         Integer washerCount,
+
+        @Min(value = 0, message = "건조기 개수는 0개 이상이어야 합니다.")
         Integer dryerCount,
+
         Boolean wifiAvailable,
         Boolean parkingAvailable,
         Boolean petAvailable,

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDetailUpdateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationDetailUpdateRequestDTO.java
@@ -1,17 +1,39 @@
 package com.project.cozystay.accommodation.dto;
 
+import jakarta.validation.constraints.Min;
+
 public record AccommodationDetailUpdateRequestDTO(
 
+        @Min(value = 0, message = "방 개수는 0개 이상이어야 합니다.")
         Integer roomCount,
+
+        @Min(value = 0, message = "침실 개수는 0개 이상이어야 합니다.")
         Integer bedroomCount,
+
+        @Min(value = 0, message = "침대 개수는 0개 이상이어야 합니다.")
         Integer bedCount,
+
+        @Min(value = 0, message = "욕실 개수는 0개 이상이어야 합니다.")
         Integer bathroomCount,
+
+        @Min(value = 0, message = "에어컨 개수는 0개 이상이어야 합니다.")
         Integer airConditionerCount,
+
+        @Min(value = 0, message = "헤어드라이어 개수는 0개 이상이어야 합니다.")
         Integer hairDryerCount,
+
+        @Min(value = 0, message = "냉장고 개수는 0개 이상이어야 합니다.")
         Integer refrigeratorCount,
+
+        @Min(value = 0, message = "TV 개수는 0개 이상이어야 합니다.")
         Integer televisionCount,
+
+        @Min(value = 0, message = "세탁기 개수는 0개 이상이어야 합니다.")
         Integer washerCount,
+
+        @Min(value = 0, message = "건조기 개수는 0개 이상이어야 합니다.")
         Integer dryerCount,
+
         Boolean wifiAvailable,
         Boolean parkingAvailable,
         Boolean petAvailable,

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageCategoryRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageCategoryRequestDTO.java
@@ -1,7 +1,12 @@
 package com.project.cozystay.accommodation.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record AccommodationImageCategoryRequestDTO(
+        @NotBlank(message = "카테고리 이름은 필수입니다.")
         String name,
+
+        @jakarta.validation.constraints.Min(value = 0, message = "정렬 순서는 0 이상이어야 합니다.")
         Integer displayOrder
 ) {
 }

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationImageRequestDTO.java
@@ -1,9 +1,11 @@
 package com.project.cozystay.accommodation.dto;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record AccommodationImageRequestDTO(
-        @NotNull
+        @NotNull(message = "정렬 순서는 필수입니다.")
+        @Min(value = 0, message = "정렬 순서는 0 이상이어야 합니다.")
         Integer displayOrder,
 
         Boolean isPrimary,

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
@@ -2,6 +2,10 @@ package com.project.cozystay.accommodation.dto;
 
 import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.domain.AccommodationType;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,20 +18,26 @@ import java.time.LocalTime;
 @AllArgsConstructor
 public class AccommodationRequestDTO {
 
+    @NotBlank(message = "숙소 제목은 필수입니다.")
     private String title;
 
     private String description;
 
+    @NotNull(message = "숙소 타입은 필수입니다.")
     private AccommodationType accommodationType;
 
+    @NotBlank(message = "주소는 필수입니다.")
     private String address;
 
+    @NotBlank(message = "도시는 필수입니다.")
     private String city;     // 시/군 (예: 성남시, 가평군)
 
+    @NotBlank(message = "구/군은 필수입니다.")
     private String district; // 구 (예: 분당구)
 
     private String state;
 
+    @NotBlank(message = "국가는 필수입니다.")
     private String country;
 
     private String postalCode;
@@ -36,8 +46,12 @@ public class AccommodationRequestDTO {
 
     private BigDecimal longitude;
 
+    @NotNull(message = "최대 인원수는 필수입니다.")
+    @Min(value = 1, message = "최대 인원수는 1명 이상이어야 합니다.")
     private Integer maxGuests;
 
+    @NotNull(message = "1박당 가격은 필수입니다.")
+    @DecimalMin(value = "0.0", message = "가격은 0원 이상이어야 합니다.")
     private BigDecimal pricePerNight;
 
     private BigDecimal cleaningFee;
@@ -49,6 +63,14 @@ public class AccommodationRequestDTO {
     private String checkOutTime;
 
     public Accommodation toEntity(Long hostId) {
+        LocalTime parsedCheckIn = (this.checkInTime != null && !this.checkInTime.isBlank())
+                ? LocalTime.parse(this.checkInTime)
+                : LocalTime.of(15, 0); // 기본 체크인 15:00
+
+        LocalTime parsedCheckOut = (this.checkOutTime != null && !this.checkOutTime.isBlank())
+                ? LocalTime.parse(this.checkOutTime)
+                : LocalTime.of(11, 0); // 기본 체크아웃 11:00
+
         return Accommodation.builder()
                 .hostId(hostId)
                 .title(this.title)
@@ -66,8 +88,8 @@ public class AccommodationRequestDTO {
                 .pricePerNight(this.pricePerNight)
                 .cleaningFee(this.cleaningFee != null ? this.cleaningFee : BigDecimal.ZERO)
                 .instantBooking(this.instantBooking != null ? this.instantBooking : false)
-                .checkInTime(LocalTime.parse(this.checkInTime))
-                .checkOutTime(LocalTime.parse(this.checkOutTime))
+                .checkInTime(parsedCheckIn)
+                .checkOutTime(parsedCheckOut)
                 .build();
     }
 }

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
@@ -6,88 +6,81 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class AccommodationRequestDTO {
-
+public record AccommodationRequestDTO(
     @NotBlank(message = "숙소 제목은 필수입니다.")
-    private String title;
+    String title,
 
-    private String description;
+    String description,
 
     @NotNull(message = "숙소 타입은 필수입니다.")
-    private AccommodationType accommodationType;
+    AccommodationType accommodationType,
 
     @NotBlank(message = "주소는 필수입니다.")
-    private String address;
+    String address,
 
     @NotBlank(message = "도시는 필수입니다.")
-    private String city;     // 시/군 (예: 성남시, 가평군)
+    String city,
 
     @NotBlank(message = "구/군은 필수입니다.")
-    private String district; // 구 (예: 분당구)
+    String district,
 
-    private String state;
+    String state,
 
     @NotBlank(message = "국가는 필수입니다.")
-    private String country;
+    String country,
 
-    private String postalCode;
+    String postalCode,
 
-    private BigDecimal latitude;
+    BigDecimal latitude,
 
-    private BigDecimal longitude;
+    BigDecimal longitude,
 
     @NotNull(message = "최대 인원수는 필수입니다.")
     @Min(value = 1, message = "최대 인원수는 1명 이상이어야 합니다.")
-    private Integer maxGuests;
+    Integer maxGuests,
 
     @NotNull(message = "1박당 가격은 필수입니다.")
     @DecimalMin(value = "0.0", message = "가격은 0원 이상이어야 합니다.")
-    private BigDecimal pricePerNight;
+    BigDecimal pricePerNight,
 
-    private BigDecimal cleaningFee;
+    BigDecimal cleaningFee,
 
-    private Boolean instantBooking;
+    Boolean instantBooking,
 
-    private String checkInTime;
+    String checkInTime,
 
-    private String checkOutTime;
-
+    String checkOutTime
+) {
     public Accommodation toEntity(Long hostId) {
-        LocalTime parsedCheckIn = (this.checkInTime != null && !this.checkInTime.isBlank())
-                ? LocalTime.parse(this.checkInTime)
-                : LocalTime.of(15, 0); // 기본 체크인 15:00
+        LocalTime parsedCheckIn = (checkInTime != null && !checkInTime.isBlank())
+                ? LocalTime.parse(checkInTime)
+                : LocalTime.of(15, 0);
 
-        LocalTime parsedCheckOut = (this.checkOutTime != null && !this.checkOutTime.isBlank())
-                ? LocalTime.parse(this.checkOutTime)
-                : LocalTime.of(11, 0); // 기본 체크아웃 11:00
+        LocalTime parsedCheckOut = (checkOutTime != null && !checkOutTime.isBlank())
+                ? LocalTime.parse(checkOutTime)
+                : LocalTime.of(11, 0);
 
         return Accommodation.builder()
                 .hostId(hostId)
-                .title(this.title)
-                .description(this.description)
-                .accommodationType(this.accommodationType)
-                .address(this.address)
-                .city(this.city)
-                .district(this.district)
-                .state(this.state)
-                .country(this.country)
-                .postalCode(this.postalCode)
-                .latitude(this.latitude)
-                .longitude(this.longitude)
-                .maxGuests(this.maxGuests)
-                .pricePerNight(this.pricePerNight)
-                .cleaningFee(this.cleaningFee != null ? this.cleaningFee : BigDecimal.ZERO)
-                .instantBooking(this.instantBooking != null ? this.instantBooking : false)
+                .title(title)
+                .description(description)
+                .accommodationType(accommodationType)
+                .address(address)
+                .city(city)
+                .district(district)
+                .state(state)
+                .country(country)
+                .postalCode(postalCode)
+                .latitude(latitude)
+                .longitude(longitude)
+                .maxGuests(maxGuests)
+                .pricePerNight(pricePerNight)
+                .cleaningFee(cleaningFee != null ? cleaningFee : BigDecimal.ZERO)
+                .instantBooking(instantBooking != null ? instantBooking : false)
                 .checkInTime(parsedCheckIn)
                 .checkOutTime(parsedCheckOut)
                 .build();

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
@@ -1,7 +1,6 @@
 package com.project.cozystay.accommodation.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.domain.AccommodationType;
 import jakarta.validation.constraints.*;
 
@@ -57,32 +56,10 @@ public record AccommodationRequestDTO(
 
     Boolean instantBooking,
 
-    @JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime checkInTime,
 
-    @JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime checkOutTime
 ) {
-    public Accommodation toEntity(Long hostId) {
-        return Accommodation.builder()
-                .hostId(hostId)
-                .title(title)
-                .description(description)
-                .accommodationType(accommodationType)
-                .address(address)
-                .city(city)
-                .district(district)
-                .state(state)
-                .country(country)
-                .postalCode(postalCode)
-                .latitude(latitude)
-                .longitude(longitude)
-                .maxGuests(maxGuests)
-                .pricePerNight(pricePerNight)
-                .cleaningFee(cleaningFee != null ? cleaningFee : BigDecimal.ZERO)
-                .instantBooking(instantBooking != null ? instantBooking : false)
-                .checkInTime(checkInTime != null ? checkInTime : LocalTime.of(15, 0))
-                .checkOutTime(checkOutTime != null ? checkOutTime : LocalTime.of(11, 0))
-                .build();
-    }
 }

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
@@ -1,5 +1,6 @@
 package com.project.cozystay.accommodation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.domain.AccommodationType;
 import jakarta.validation.constraints.*;
@@ -25,6 +26,7 @@ public record AccommodationRequestDTO(
     @NotBlank(message = "구/군은 필수입니다.")
     String district,
 
+    @NotBlank(message = "시/도는 필수입니다.")
     String state,
 
     @NotBlank(message = "국가는 필수입니다.")
@@ -55,10 +57,10 @@ public record AccommodationRequestDTO(
 
     Boolean instantBooking,
 
-    @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    @JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime checkInTime,
 
-    @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    @JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm")
     LocalTime checkOutTime
 ) {
     public Accommodation toEntity(Long hostId) {

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
@@ -1,5 +1,6 @@
 package com.project.cozystay.accommodation.dto;
 
+import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.domain.AccommodationType;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
@@ -34,8 +35,10 @@ public record AccommodationRequestDTO(
 
     String postalCode,
 
+    @NotNull(message = "위도는 필수입니다.")
     BigDecimal latitude,
 
+    @NotNull(message = "경도는 필수입니다.")
     BigDecimal longitude,
 
     @NotNull(message = "최대 인원수는 필수입니다.")
@@ -46,23 +49,16 @@ public record AccommodationRequestDTO(
     @DecimalMin(value = "0.0", message = "가격은 0원 이상이어야 합니다.")
     BigDecimal pricePerNight,
 
+    @DecimalMin(value = "0.0", message = "청소비는 0원 이상이어야 합니다.")
     BigDecimal cleaningFee,
 
     Boolean instantBooking,
 
-    String checkInTime,
+    LocalTime checkInTime,
 
-    String checkOutTime
+    LocalTime checkOutTime
 ) {
     public Accommodation toEntity(Long hostId) {
-        LocalTime parsedCheckIn = (checkInTime != null && !checkInTime.isBlank())
-                ? LocalTime.parse(checkInTime)
-                : LocalTime.of(15, 0);
-
-        LocalTime parsedCheckOut = (checkOutTime != null && !checkOutTime.isBlank())
-                ? LocalTime.parse(checkOutTime)
-                : LocalTime.of(11, 0);
-
         return Accommodation.builder()
                 .hostId(hostId)
                 .title(title)
@@ -80,8 +76,8 @@ public record AccommodationRequestDTO(
                 .pricePerNight(pricePerNight)
                 .cleaningFee(cleaningFee != null ? cleaningFee : BigDecimal.ZERO)
                 .instantBooking(instantBooking != null ? instantBooking : false)
-                .checkInTime(parsedCheckIn)
-                .checkOutTime(parsedCheckOut)
+                .checkInTime(checkInTime != null ? checkInTime : LocalTime.of(15, 0))
+                .checkOutTime(checkOutTime != null ? checkOutTime : LocalTime.of(11, 0))
                 .build();
     }
 }

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationRequestDTO.java
@@ -2,10 +2,7 @@ package com.project.cozystay.accommodation.dto;
 
 import com.project.cozystay.accommodation.domain.Accommodation;
 import com.project.cozystay.accommodation.domain.AccommodationType;
-import jakarta.validation.constraints.DecimalMin;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
@@ -36,9 +33,13 @@ public record AccommodationRequestDTO(
     String postalCode,
 
     @NotNull(message = "위도는 필수입니다.")
+    @DecimalMin(value = "-90.0", message = "위도는 -90.0 이상이어야 합니다.")
+    @DecimalMax(value = "90.0", message = "위도는 90.0 이하이어야 합니다.")
     BigDecimal latitude,
 
     @NotNull(message = "경도는 필수입니다.")
+    @DecimalMin(value = "-180.0", message = "경도는 -180.0 이상이어야 합니다.")
+    @DecimalMax(value = "180.0", message = "경도는 180.0 이하이어야 합니다.")
     BigDecimal longitude,
 
     @NotNull(message = "최대 인원수는 필수입니다.")
@@ -54,8 +55,10 @@ public record AccommodationRequestDTO(
 
     Boolean instantBooking,
 
+    @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     LocalTime checkInTime,
 
+    @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     LocalTime checkOutTime
 ) {
     public Accommodation toEntity(Long hostId) {

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
@@ -1,27 +1,54 @@
 package com.project.cozystay.accommodation.dto;
 
 import com.project.cozystay.accommodation.domain.AccommodationType;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import java.math.BigDecimal;
 import java.time.LocalTime;
 
 public record AccommodationUpdateRequestDTO(
 
+        @NotBlank(message = "숙소 제목은 필수입니다.")
         String title,
+
         String description,
+
         AccommodationType accommodationType,
+
+        @NotBlank(message = "주소는 필수입니다.")
         String address,
+
+        @NotBlank(message = "도시는 필수입니다.")
         String city,
+
+        @NotBlank(message = "구/군은 필수입니다.")
         String district,
+
         String state,
+
+        @NotBlank(message = "국가는 필수입니다.")
         String country,
+
         String postalCode,
+
         BigDecimal latitude,
+
         BigDecimal longitude,
+
+        @Min(value = 1, message = "최대 인원수는 1명 이상이어야 합니다.")
         Integer maxGuests,
+
+        @DecimalMin(value = "0.0", message = "가격은 0원 이상이어야 합니다.")
         BigDecimal pricePerNight,
+
+        @DecimalMin(value = "0.0", message = "청소비는 0원 이상이어야 합니다.")
         BigDecimal cleaningFee,
+
         Boolean instantBooking,
+
         LocalTime checkInTime,
+
         LocalTime checkOutTime
 ) {
 }

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
@@ -5,32 +5,25 @@ import com.project.cozystay.accommodation.domain.AccommodationType;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import java.math.BigDecimal;
 import java.time.LocalTime;
 
 public record AccommodationUpdateRequestDTO(
 
-        @NotBlank(message = "숙소 제목은 필수입니다.")
         String title,
 
         String description,
 
         AccommodationType accommodationType,
 
-        @NotBlank(message = "주소는 필수입니다.")
         String address,
 
-        @NotBlank(message = "도시는 필수입니다.")
         String city,
 
-        @NotBlank(message = "구/군은 필수입니다.")
         String district,
 
-        @NotBlank(message = "시/도는 필수입니다.")
         String state,
 
-        @NotBlank(message = "국가는 필수입니다.")
         String country,
 
         String postalCode,

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
@@ -32,8 +32,12 @@ public record AccommodationUpdateRequestDTO(
 
         String postalCode,
 
+        @jakarta.validation.constraints.DecimalMin(value = "-90.0", message = "위도는 -90.0 이상이어야 합니다.")
+        @jakarta.validation.constraints.DecimalMax(value = "90.0", message = "위도는 90.0 이하이어야 합니다.")
         BigDecimal latitude,
 
+        @jakarta.validation.constraints.DecimalMin(value = "-180.0", message = "경도는 -180.0 이상이어야 합니다.")
+        @jakarta.validation.constraints.DecimalMax(value = "180.0", message = "경도는 180.0 이하이어야 합니다.")
         BigDecimal longitude,
 
         @Min(value = 1, message = "최대 인원수는 1명 이상이어야 합니다.")
@@ -47,8 +51,10 @@ public record AccommodationUpdateRequestDTO(
 
         Boolean instantBooking,
 
+        @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
         LocalTime checkInTime,
 
+        @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
         LocalTime checkOutTime
 ) {
 }

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationUpdateRequestDTO.java
@@ -1,6 +1,8 @@
 package com.project.cozystay.accommodation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.cozystay.accommodation.domain.AccommodationType;
+import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -25,6 +27,7 @@ public record AccommodationUpdateRequestDTO(
         @NotBlank(message = "구/군은 필수입니다.")
         String district,
 
+        @NotBlank(message = "시/도는 필수입니다.")
         String state,
 
         @NotBlank(message = "국가는 필수입니다.")
@@ -32,12 +35,12 @@ public record AccommodationUpdateRequestDTO(
 
         String postalCode,
 
-        @jakarta.validation.constraints.DecimalMin(value = "-90.0", message = "위도는 -90.0 이상이어야 합니다.")
-        @jakarta.validation.constraints.DecimalMax(value = "90.0", message = "위도는 90.0 이하이어야 합니다.")
+        @DecimalMin(value = "-90.0", message = "위도는 -90.0 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "위도는 90.0 이하이어야 합니다.")
         BigDecimal latitude,
 
-        @jakarta.validation.constraints.DecimalMin(value = "-180.0", message = "경도는 -180.0 이상이어야 합니다.")
-        @jakarta.validation.constraints.DecimalMax(value = "180.0", message = "경도는 180.0 이하이어야 합니다.")
+        @DecimalMin(value = "-180.0", message = "경도는 -180.0 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "경도는 180.0 이하이어야 합니다.")
         BigDecimal longitude,
 
         @Min(value = 1, message = "최대 인원수는 1명 이상이어야 합니다.")
@@ -51,10 +54,10 @@ public record AccommodationUpdateRequestDTO(
 
         Boolean instantBooking,
 
-        @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        @JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm")
         LocalTime checkInTime,
 
-        @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        @JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm")
         LocalTime checkOutTime
 ) {
 }

--- a/src/main/java/com/project/cozystay/booking/domain/BookingStatus.java
+++ b/src/main/java/com/project/cozystay/booking/domain/BookingStatus.java
@@ -1,9 +1,18 @@
 package com.project.cozystay.booking.domain;
 
+import java.util.List;
+
 public enum BookingStatus {
     PENDING,
     CONFIRMED,
     REJECTED,
     CANCELLED,
-    COMPLETED
+    COMPLETED;
+
+    /**
+     * 예약 가능 여부를 판단할 때 '예약됨'으로 간주하는 활성 상태 목록
+     */
+    public static List<BookingStatus> getActiveStatuses() {
+        return List.of(PENDING, CONFIRMED);
+    }
 }

--- a/src/main/java/com/project/cozystay/booking/service/BookingAvailabilityCommandService.java
+++ b/src/main/java/com/project/cozystay/booking/service/BookingAvailabilityCommandService.java
@@ -71,7 +71,7 @@ public class BookingAvailabilityCommandService {
 
             boolean hasOverlap = bookingRepository.existsActiveBookingOverlapping(
                     accommodationId,
-                    List.of(BookingStatus.PENDING, BookingStatus.CONFIRMED),
+                    BookingStatus.getActiveStatuses(),
                     startInclusive,
                     endExclusive
             );

--- a/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
@@ -45,6 +45,17 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(msg));
     }
 
+    @ExceptionHandler(jakarta.validation.ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(jakarta.validation.ConstraintViolationException e) {
+        String msg = e.getConstraintViolations().stream()
+                .findFirst()
+                .map(jakarta.validation.ConstraintViolation::getMessage)
+                .orElse("요청 값이 올바르지 않습니다.");
+        log.warn("BadRequest [ConstraintViolation]: {}", msg);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(msg));
+    }
+
     /* ===================== 401 UNAUTHORIZED ===================== */
     @ExceptionHandler({AuthenticationRequiredException.class, BadCredentialsException.class})
     public ResponseEntity<ErrorResponse> handleUnauthorized(Exception e){

--- a/src/main/java/com/project/cozystay/global/init/DataInitializer.java
+++ b/src/main/java/com/project/cozystay/global/init/DataInitializer.java
@@ -115,7 +115,7 @@ public class DataInitializer implements CommandLineRunner {
 
         for (int i = 1; i <= 50; i++) {
             User host = hosts.get(random.nextInt(hosts.size()));
-            String[] states = {"서울특별시", "경기도", "강원도", "부산광역시", "제주특별자치도", "전라남도", "경상북도"};
+            String[] states = {"서울", "경기", "강원", "부산", "제주", "전남", "경북"};
             String[] cities = {"강남구", "성남시", "강릉시", "해운대구", "제주시", "여수시", "경주시"};
             String[] districts = {"신사동", "분당구", "교동", "우동", "연동", "학동", "황남동"};
 

--- a/src/main/java/com/project/cozystay/search/repository/AccommodationElasticSearchRepository.java
+++ b/src/main/java/com/project/cozystay/search/repository/AccommodationElasticSearchRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import java.util.List;
 
 /**
- * 숙소의 기본 CRUD 담당
+ * 숙소 검색의 기본 CRUD 담당
  */
 public interface AccommodationElasticSearchRepository extends ElasticsearchRepository<AccommodationDocument, Long>, AccommodationElasticSearchRepositoryCustom {
 

--- a/src/main/java/com/project/cozystay/search/repository/AccommodationElasticSearchRepository.java
+++ b/src/main/java/com/project/cozystay/search/repository/AccommodationElasticSearchRepository.java
@@ -1,44 +1,13 @@
 package com.project.cozystay.search.repository;
 
 import com.project.cozystay.search.domain.AccommodationDocument;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import java.util.List;
 
-public interface AccommodationElasticSearchRepository extends ElasticsearchRepository<AccommodationDocument, Long> {
-
-    /**
-     * 최종 정밀 튜닝된 키워드 검색
-     * - 노이즈 제거: 모든 숙소에 공통적으로 들어가는 description 필드를 검색 대상에서 제외하여 정확도 향상
-     * - Operator OR: 검색어 중 하나만 포함되어도 검색 결과에 노출 (연관 검색 지원)
-     * - Fuzziness 1: '재주' -> '제주'와 같은 오타 교정은 유지
-     */
-    @Query("{" +
-            "  \"bool\": {" +
-            "    \"must\": [" +
-            "      {" +
-            "        \"multi_match\": {" +
-            "          \"query\": \"?0\"," +
-            "          \"fields\": [\"title^3\", \"city^2\", \"state\", \"district\"]," +
-            "          \"operator\": \"OR\"," +
-            "          \"fuzziness\": 1" +
-            "        }" +
-            "      }" +
-            "    ]," +
-            "    \"must_not\": [" +
-            "      {" +
-            "        \"terms\": {" +
-            "          \"id\": ?1" +
-            "        }" +
-            "      }" +
-            "    ]" +
-            "  }" +
-            "}")
-    Page<AccommodationDocument> searchByKeywordAndExcludeIds(String keyword, List<Long> excludedIds, Pageable pageable);
-
-    Page<AccommodationDocument> findByIdNotIn(List<Long> excludedIds, Pageable pageable);
+/**
+ * 숙소의 기본 CRUD 담당
+ */
+public interface AccommodationElasticSearchRepository extends ElasticsearchRepository<AccommodationDocument, Long>, AccommodationElasticSearchRepositoryCustom {
 
     List<AccommodationDocument> findByTitleOrAddress(String title, String address);
 }

--- a/src/main/java/com/project/cozystay/search/repository/AccommodationElasticSearchRepositoryCustom.java
+++ b/src/main/java/com/project/cozystay/search/repository/AccommodationElasticSearchRepositoryCustom.java
@@ -1,0 +1,20 @@
+package com.project.cozystay.search.repository;
+
+import com.project.cozystay.search.domain.AccommodationDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+/**
+ * 숙소 검색 고도화를 위한 인터페이스
+ */
+public interface AccommodationElasticSearchRepositoryCustom {
+    Page<AccommodationDocument> searchAccommodations(
+            String title,
+            String state,
+            String city,
+            String district,
+            List<Long> excludedIds,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/project/cozystay/search/repository/AccommodationElasticSearchRepositoryImpl.java
+++ b/src/main/java/com/project/cozystay/search/repository/AccommodationElasticSearchRepositoryImpl.java
@@ -1,0 +1,105 @@
+package com.project.cozystay.search.repository;
+
+import com.project.cozystay.search.domain.AccommodationDocument;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchPage;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * 숙소 검색 고도화를 위한 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class AccommodationElasticSearchRepositoryImpl implements AccommodationElasticSearchRepositoryCustom {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Override
+    public Page<AccommodationDocument> searchAccommodations(
+            String title,
+            String state,
+            String city,
+            String district,
+            List<Long> excludedIds,
+            Pageable pageable
+    ) {
+        NativeQueryBuilder queryBuilder = new NativeQueryBuilder();
+        
+        BoolQuery.Builder boolQueryBuilder = QueryBuilders.bool();
+
+        // 1. 숙소명 검색 (Full Text Search)
+        if (StringUtils.hasText(title)) {
+            boolQueryBuilder.must(q -> q
+                .match(m -> m
+                    .field("title")
+                    .query(title)
+                    .fuzziness("1")
+                )
+            );
+        }
+
+        // 2. 주소(state, city, district 등) 필터
+        if (StringUtils.hasText(state)) {
+            boolQueryBuilder.filter(q -> q
+                .term(t -> t
+                    .field("state")
+                    .value(state)
+                )
+            );
+        }
+
+        if (StringUtils.hasText(city)) {
+            boolQueryBuilder.filter(q -> q
+                .term(t -> t
+                    .field("city")
+                    .value(city)
+                )
+            );
+        }
+
+        if (StringUtils.hasText(district)) {
+            boolQueryBuilder.filter(q -> q
+                .term(t -> t
+                    .field("district")
+                    .value(district)
+                )
+            );
+        }
+
+        // 3. 이미 예약된 날짜 제외
+        if (excludedIds != null && !excludedIds.isEmpty()) {
+            List<FieldValue> fieldValues = excludedIds.stream()
+                    .map(FieldValue::of)
+                    .toList();
+
+            boolQueryBuilder.mustNot(q -> q
+                .terms(t -> t
+                    .field("id")
+                    .terms(v -> v.value(fieldValues))
+                )
+            );
+        }
+
+        queryBuilder.withQuery(boolQueryBuilder.build()._toQuery());
+        queryBuilder.withPageable(pageable);
+
+        Query query = queryBuilder.build();
+        SearchHits<AccommodationDocument> searchHits = elasticsearchOperations.search(query, AccommodationDocument.class);
+        SearchPage<AccommodationDocument> searchPage = SearchHitSupport.searchPageFor(searchHits, pageable);
+
+        return (Page<AccommodationDocument>) SearchHitSupport.unwrapSearchHits(searchPage);
+    }
+}

--- a/src/main/java/com/project/cozystay/search/repository/AccommodationJPASearchRepositoryImpl.java
+++ b/src/main/java/com/project/cozystay/search/repository/AccommodationJPASearchRepositoryImpl.java
@@ -110,13 +110,11 @@ public class AccommodationJPASearchRepositoryImpl implements AccommodationJPASea
             return null;
         }
 
-        List<BookingStatus> activeStatuses = List.of(BookingStatus.PENDING, BookingStatus.CONFIRMED);
-
         return JPAExpressions.selectOne()
                 .from(booking)
                 .where(
                         booking.accommodation.id.eq(accommodation.id),
-                        booking.status.in(activeStatuses),
+                        booking.status.in(BookingStatus.getActiveStatuses()),
                         booking.checkOutDate.after(checkIn),
                         booking.checkInDate.before(checkOut)
                 )

--- a/src/main/java/com/project/cozystay/search/repository/AccommodationJPASearchRepositoryImpl.java
+++ b/src/main/java/com/project/cozystay/search/repository/AccommodationJPASearchRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.project.cozystay.search.repository;
 
 import com.project.cozystay.accommodation.domain.AccommodationStatus;
+import com.project.cozystay.booking.domain.BookingStatus;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
@@ -109,11 +110,13 @@ public class AccommodationJPASearchRepositoryImpl implements AccommodationJPASea
             return null;
         }
 
-        // NOT IN 대신 NOT EXISTS 사용
+        List<BookingStatus> activeStatuses = List.of(BookingStatus.PENDING, BookingStatus.CONFIRMED);
+
         return JPAExpressions.selectOne()
                 .from(booking)
                 .where(
                         booking.accommodation.id.eq(accommodation.id),
+                        booking.status.in(activeStatuses),
                         booking.checkOutDate.after(checkIn),
                         booking.checkInDate.before(checkOut)
                 )

--- a/src/main/java/com/project/cozystay/search/service/SearchService.java
+++ b/src/main/java/com/project/cozystay/search/service/SearchService.java
@@ -44,7 +44,7 @@ public class SearchService {
         if (request.getCheckInDate() != null && request.getCheckOutDate() != null) {
             log.info("예약 필터링을 위한 숙소 ID 조회: {} ~ {}", request.getCheckInDate(), request.getCheckOutDate());
             bookedIds = bookingRepository.findAllBookedAccommodationIdsByDateRange(
-                    Arrays.asList(BookingStatus.PENDING, BookingStatus.CONFIRMED),
+                    BookingStatus.getActiveStatuses(),
                     request.getCheckInDate(),
                     request.getCheckOutDate()
             );

--- a/src/main/java/com/project/cozystay/search/service/SearchService.java
+++ b/src/main/java/com/project/cozystay/search/service/SearchService.java
@@ -16,15 +16,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -55,35 +51,26 @@ public class SearchService {
             log.info("제외될 예약된 숙소 수: {}건", bookedIds.size());
         }
 
-        // 2. 키워드 추출
-        String keyword = Stream.of(request.getTitle(), request.getState(), request.getCity(), request.getDistrict())
-                .filter(Objects::nonNull)
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.joining(" "));
-
-        if (keyword.isEmpty()) {
-            keyword = null;
-        }
-
-        // 3. Elasticsearch 검색 시도 (우선순위 1)
+        // 2. Elasticsearch 검색 시도 (우선순위 1)
         try {
-            Page<AccommodationDocument> esPage;
-            if (keyword != null && !keyword.isEmpty()) {
-                log.info("Elasticsearch 고도화 검색 실행 (필터 포함): keyword={}, excludedCount={}", keyword, bookedIds.size());
-                esPage = accommodationElasticSearchRepository.searchByKeywordAndExcludeIds(keyword, bookedIds, pageable);
-            } else if (!bookedIds.isEmpty()) {
-                log.info("검색어 없이 예약 제외 필터링만 수행합니다: excludedCount={}", bookedIds.size());
-                esPage = accommodationElasticSearchRepository.findByIdNotIn(bookedIds, pageable);
-            } else {
-                log.info("검색어와 예약 필터가 없어 ES 전체 페이징 조회를 수행합니다.");
-                esPage = accommodationElasticSearchRepository.findAll(pageable);
-            }
+            String title = StringUtils.hasText(request.getTitle()) ? request.getTitle().trim() : null;
+            
+            log.info("Elasticsearch 검색 실행: title={}, state={}, city={}, district={}, excludedCount={}",
+                    title, request.getState(), request.getCity(), request.getDistrict(), bookedIds.size());
+
+            Page<AccommodationDocument> esPage = accommodationElasticSearchRepository.searchAccommodations(
+                    title,
+                    request.getState(),
+                    request.getCity(),
+                    request.getDistrict(),
+                    bookedIds,
+                    pageable
+            );
 
             return AccommodationSearchResponse.fromDocuments(esPage);
 
         } catch (Exception e) {
-            // 4. ES 장애 발생 시 JPA(QueryDSL)로 Fallback
+            // 3. ES 장애 발생 시 JPA(QueryDSL)로 Fallback
             log.error("Elasticsearch 장애 발생! JPA(QueryDSL) 검색으로 전환합니다. 사유: {}", e.getMessage());
             Page<Tuple> jpaPage = accommodationJPASearchRepository.search(request, bookedIds, pageable);
             return AccommodationSearchResponse.from(jpaPage);


### PR DESCRIPTION
## 🔗 반영 브랜치

(#) refactor/search -> develop

## 📝 작업 내용

1. Elasticsearch 검색 로직 고도화
   - 필드 분리 필터링 구현: state, city, district를 별도의 필드로 분리하여 term 쿼리(정합 일치)를 적용했습니다. 이제
     지역 필터가 숙소 이름에 포함된 단어에 간섭받지 않고 100% 정확하게 작동합니다.
   - 제목 검색 최적화: title 필드는 기존처럼 nori 분석기와 fuzziness를 유지하여 유연한 검색어 대응이 가능하게 했습니다.
   - 커스텀 레포지토리 도입: 복잡해진 동적 쿼리를 처리하기 위해 AccommodationElasticSearchRepositoryCustom 인터페이스와
     구현체(Impl)를 추가하여 유지보수성을 높였습니다.

  2. 검색 정합성 및 예약 필터링 강화
   - 예약 상태 조건 추가: 기존에 모든 예약 건을 제외하던 로직을 수정하여, 실질적으로 방을 차지하고 있는 PENDING,
     CONFIRMED 상태의 예약만 제외하도록 개선했습니다.
   - JPA Fallback 로직 동기화: ES 장애 시 작동하는 JPA(QueryDSL) 검색 로직도 위와 동일한 지역 필터 및 예약 상태 조건을
     갖추도록 리팩토링했습니다.

  3. DTO 제약 조건 및 데이터 형식 수정
   - 주소 필드 검증 강화: state, city, district 필드에 @NotBlank를 추가하여 데이터의 무결성을 확보했습니다.
   - 시간 형식 대응: 프론트엔드 전송 포맷에 맞춰 LocalTime의 @JsonFormat 패턴을 HH:mm:ss -> HH:mm으로 수정하여
     데시리얼라이즈 에러를 해결했습니다.

  📈 개선 결과
   - 검색 정확도: "제주" 필터 선택 시 제목에 "제주"가 들어간 "서울" 숙소가 노출되던 이슈를 완벽히 해결했습니다.
   - 사용자 경험: 제목 없이 지역과 날짜만으로도 예약 가능한 숙소 목록을 정확히 필터링할 수 있습니다.
   - 안정성: title이 null이거나 공백으로 들어올 경우에 대한 예외 처리를 완료했습니다.


## 테스트 결과
제주-제주시 선택, 숙소명으로 38을 입력시 38과 관련된 숙소들이 검색 됩니다.
'3', '8'로 나누어 각 숫자가 들어간 숙소명이 차선으로 검색 됩니다.

<img width="708" height="66" alt="image" src="https://github.com/user-attachments/assets/8187d89f-09de-4347-8177-2a49ffe73012" />
<img width="770" height="1142" alt="image" src="https://github.com/user-attachments/assets/e5b0f469-6b87-4fed-879a-7d36a4316b7f" />


  ---

  작업한 파일 목록:
   - SearchService.java
   - AccommodationElasticSearchRepositoryCustom.java (신규)
   - AccommodationElasticSearchRepositoryImpl.java (신규)
   - AccommodationElasticSearchRepository.java
   - AccommodationJPASearchRepositoryImpl.java
   - AccommodationRequestDTO.java
   - AccommodationUpdateRequestDTO.java
   
## 💬 리뷰 요구사항
- 현재 게스트 수(인원수) 필터는 검색 로직에 반영되어 있지 않습니다.