### PR TITLE
Refactor : 채팅방 생성 시 검증 로직 추가

### DIFF
--- a/src/main/java/com/project/cozystay/accommodation/domain/Accommodation.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/Accommodation.java
@@ -174,6 +174,13 @@ public class Accommodation {
         }
     }
 
+    public void validateHost(Long requestHostId){
+        if(!this.hostId.equals(requestHostId)){
+            throw new IllegalStateException("요청한 HostId와 숙소의 소유자가 다릅니다.");
+        }
+    }
+
+
     public static Accommodation create(Long hostId, AccommodationRequestDTO request) {
         return Accommodation.builder()
                 .hostId(hostId)

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -226,10 +226,9 @@ public class AccommodationService {
      * 외부 비즈니스 로직에서 숙소의 주인과 요청한 사람이 맞는지 검증 후, hostId를 반환하는 메서드
      */
     @Transactional(readOnly = true)
-    public Long accommodationHostCheck(Long requestAccommodationId, Long requestHostId){
+    public void accommodationHostCheck(Long requestAccommodationId, Long requestHostId){
         Accommodation accommodation = getAccommodation(requestAccommodationId);
         accommodation.validateHost(requestHostId);
-        return accommodation.getHostId();
     }
 
 

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -222,10 +222,18 @@ public class AccommodationService {
                 .build();
     }
 
-
     /**
-     * 숙소의 주인과 요청한 사람이 맞는지 비교하는 공통 메서드
+     * 외부 비즈니스 로직에서 숙소의 주인과 요청한 사람이 맞는지 검증 후, hostId를 반환하는 메서드
      */
+    @Transactional(readOnly = true)
+    public Long accommodationHostCheck(Long requestAccommodationId, Long requestHostId){
+        Accommodation accommodation = getAccommodation(requestAccommodationId);
+        accommodation.validateHost(requestHostId);
+        return accommodation.getHostId();
+    }
+
+
+    //Todo : Accommodation 도메인 내에서 검증하도록 수정
     private void accommodationHostCheck(Accommodation accommodation, Long hostId){
         if (!accommodation.getHostId().equals(hostId)){
             throw new IllegalStateException("숙소의 소유자만 수정할 수 있습니다.");

--- a/src/main/java/com/project/cozystay/chat/controller/ChatController.java
+++ b/src/main/java/com/project/cozystay/chat/controller/ChatController.java
@@ -5,20 +5,15 @@ import com.project.cozystay.chat.dto.*;
 import com.project.cozystay.chat.service.ConversationFacade;
 import com.project.cozystay.chat.service.MessageService;
 import com.project.cozystay.chat.service.ConversationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 
 @Tag(name = "Chat", description = "채팅(대화방 및 메시지) 관련 API")
@@ -35,7 +30,7 @@ public class ChatController {
     @PostMapping
     public ConversationCreateResponseDTO createOrGetConversation(
             @AuthenticationPrincipal CustomOAuth2User principal,
-            @RequestBody ConversationCreateRequestDTO request
+            @Valid @RequestBody ConversationCreateRequestDTO request
     ) {
         Long guestId = principal.getId();
         return conversationService.createOrGetConversation(request, guestId);

--- a/src/main/java/com/project/cozystay/chat/service/ConversationService.java
+++ b/src/main/java/com/project/cozystay/chat/service/ConversationService.java
@@ -7,6 +7,7 @@ import com.project.cozystay.chat.dto.ConversationCreateResponseDTO;
 import com.project.cozystay.chat.repository.ConversationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,6 +19,7 @@ public class ConversationService {
     private final ConversationRepository conversationRepository;
     private final AccommodationService accommodationService;
 
+    @Transactional
     public ConversationCreateResponseDTO createOrGetConversation(
             ConversationCreateRequestDTO request,
             Long guestId
@@ -25,12 +27,12 @@ public class ConversationService {
         Long accommodationId = request.getAccommodationId();
         Long requestHostId = request.getHostId();
 
-        Long hostId = accommodationService.accommodationHostCheck(accommodationId, requestHostId);
+        accommodationService.accommodationHostCheck(accommodationId, requestHostId);
 
         Conversation conversation = conversationRepository
-                .findByAccommodationIdAndHostIdAndGuestId(accommodationId, hostId, guestId)
+                .findByAccommodationIdAndHostIdAndGuestId(accommodationId, requestHostId, guestId)
                 .orElseGet(() -> conversationRepository.save(
-                        Conversation.create(accommodationId, hostId, guestId)
+                        Conversation.create(accommodationId, requestHostId, guestId)
                 ));
 
         return ConversationCreateResponseDTO.builder()

--- a/src/main/java/com/project/cozystay/chat/service/ConversationService.java
+++ b/src/main/java/com/project/cozystay/chat/service/ConversationService.java
@@ -1,5 +1,6 @@
 package com.project.cozystay.chat.service;
 
+import com.project.cozystay.accommodation.service.AccommodationService;
 import com.project.cozystay.chat.domain.Conversation;
 import com.project.cozystay.chat.dto.ConversationCreateRequestDTO;
 import com.project.cozystay.chat.dto.ConversationCreateResponseDTO;
@@ -15,13 +16,16 @@ import java.util.List;
 public class ConversationService {
 
     private final ConversationRepository conversationRepository;
+    private final AccommodationService accommodationService;
 
     public ConversationCreateResponseDTO createOrGetConversation(
             ConversationCreateRequestDTO request,
             Long guestId
     ) {
-        Long hostId = request.getHostId();
         Long accommodationId = request.getAccommodationId();
+        Long requestHostId = request.getHostId();
+
+        Long hostId = accommodationService.accommodationHostCheck(accommodationId, requestHostId);
 
         Conversation conversation = conversationRepository
                 .findByAccommodationIdAndHostIdAndGuestId(accommodationId, hostId, guestId)


### PR DESCRIPTION
## 🔗 반영 브랜치

(#56 )  refactor/chat -> develop

## 📝 작업 내용

**1. 채팅방 생성 시 요청으로 들어온 hostId에 대한 검증 로직 추가**
- 숙소 조회와 검증 흐름은 AccommodationService가 담당하고, 실제 도메인 검증은 Accommodation 도메인 내부에서 처리하도록 했습니다. 

**2. ChatController에 누락된 @Valid 어노테이션 추가**


## 💬 리뷰 요구사항
