### PR TITLE
Refactor : 숙소 상세 응답의 리뷰 통계 조회 방식 정리

### DIFF
--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
@@ -78,7 +78,7 @@ public class AccommodationFullResponseDTO {
                 .hostNickname(hostNickname)
                 .hostProfileImageUrl(hostProfileImageUrl)
                 .reviewSummary(new ReviewSummaryDTO(
-                        entity.getAverageRating() == null? 0.0 : entity.getAverageRating(),
+                        entity.getAverageRating() == null ? 0.0 : entity.getAverageRating(),
                         entity.getReviewCount() == null ? 0L : entity.getReviewCount().longValue()
                 ))
                 .title(entity.getTitle())

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationFullResponseDTO.java
@@ -70,15 +70,17 @@ public class AccommodationFullResponseDTO {
     public static AccommodationFullResponseDTO fromEntity(
             Accommodation entity,
             String hostNickname,
-            String hostProfileImageUrl,
-            ReviewSummaryDTO reviewSummary
+            String hostProfileImageUrl
     ){
         return AccommodationFullResponseDTO.builder()
                 .accommodationId(entity.getId())
                 .hostId(entity.getHostId())
                 .hostNickname(hostNickname)
                 .hostProfileImageUrl(hostProfileImageUrl)
-                .reviewSummary(reviewSummary)
+                .reviewSummary(new ReviewSummaryDTO(
+                        entity.getAverageRating() == null? 0.0 : entity.getAverageRating(),
+                        entity.getReviewCount() == null ? 0L : entity.getReviewCount().longValue()
+                ))
                 .title(entity.getTitle())
                 .description(entity.getDescription())
                 .accommodationType(entity.getAccommodationType().name())

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationService.java
@@ -5,20 +5,16 @@ import com.project.cozystay.accommodation.domain.*;
 import com.project.cozystay.accommodation.dto.*;
 import com.project.cozystay.accommodation.event.AccommodationEvent;
 import com.project.cozystay.accommodation.repository.AccommodationAmenityRepository;
-import com.project.cozystay.accommodation.repository.AccommodationImageRepository;
 import com.project.cozystay.accommodation.repository.AccommodationRepository;
 import com.project.cozystay.accommodation.repository.AmenityRepository;
-import com.project.cozystay.review.repository.AccommodationReviewRepository;
 import com.project.cozystay.user.domain.User;
 import com.project.cozystay.user.repository.UserRepository;
-import com.project.cozystay.accommodation.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -29,9 +25,7 @@ public class AccommodationService {
     private final AccommodationRepository accommodationRepository;
     private final AmenityRepository amenityRepository;
     private final UserRepository userRepository;
-    private final AccommodationReviewRepository accommodationReviewRepository;
     private final ApplicationEventPublisher eventPublisher;
-    private final AccommodationImageCategoryRepository accommodationImageCategoryRepository;
     private final AccommodationAmenityRepository accommodationAmenityRepository;
 
 
@@ -90,14 +84,10 @@ public class AccommodationService {
         User host = userRepository.findById(accommodation.getHostId())
                 .orElseThrow(()-> new IllegalArgumentException("호스트 유저가 없습니다."));
 
-        // 리뷰 요약 조회
-        ReviewSummaryDTO reviewSummary = accommodationReviewRepository.getReviewSummary(accommodationId);
-
         return AccommodationFullResponseDTO.fromEntity(
                 accommodation,
                 host.getNickName(),
-                host.getProfileImageUrl(),
-                reviewSummary
+                host.getProfileImageUrl()
         );
     }
 


### PR DESCRIPTION
## 🔗 반영 브랜치

(#70 ) refactor/reviewSummary -> develop

## 📝 작업 내용

**1. 숙소 상세 페이지 응답 (AccommodationFullResponseDTO.java)에서 리뷰 평균, 개수를 AccommodationReviewRepository에서 조회하는 것이 아닌, Accommodation 내부 값을 사용하도록 변경**

**2. AccommodationService내의 불필요한 import 문 정리**

## 💬 리뷰 요구사항
- 숙소 리뷰 수정 및 추가 시 업데이트 확인했습니다.