### PR TITLE
Feat: 동반자 회원 초대 및 인연/동반자 예약 조회 API 추가

### DIFF
--- a/src/main/java/com/project/cozystay/booking/guest/controller/BookingGuestMeQueryController.java
+++ b/src/main/java/com/project/cozystay/booking/guest/controller/BookingGuestMeQueryController.java
@@ -3,7 +3,9 @@ package com.project.cozystay.booking.guest.controller;
 import com.project.cozystay.auth.CustomOAuth2User;
 import com.project.cozystay.booking.exception.AuthenticationRequiredException;
 import com.project.cozystay.booking.guest.domain.InvitationStatus;
+import com.project.cozystay.booking.guest.dto.BookingGuestConnectionResponse;
 import com.project.cozystay.booking.guest.dto.MyInvitationResponse;
+import com.project.cozystay.booking.guest.service.BookingGuestConnectionQueryService;
 import com.project.cozystay.booking.guest.service.BookingGuestMeQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,6 +27,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Tag(name = "Booking Guest",  description = "동반 게스트 초대 목록 조회 API")
 @RequiredArgsConstructor
 @RestController
@@ -32,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookingGuestMeQueryController {
 
     private final BookingGuestMeQueryService bookingGuestMeQueryService;
+    private final BookingGuestConnectionQueryService bookingGuestConnectionQueryService;
 
     @Operation(summary = "내 동반 게스트 초대 목록 조회", description = "내가 받은 모든 동반 게스트 초대 내역을 조회합니다.")
     @GetMapping("/me")
@@ -45,5 +50,20 @@ public class BookingGuestMeQueryController {
         }
 
         return bookingGuestMeQueryService.getMyInvitations(user.getId(), status, pageable);
+    }
+
+    @Operation(
+            summary = "내 인연 목록 조회",
+            description = "수락된 동반 게스트 관계를 기준으로 내 인연 목록을 조회합니다."
+    )
+    @GetMapping("/connections")
+    public List<BookingGuestConnectionResponse> getConnections(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ){
+        if(user == null){
+            throw new AuthenticationRequiredException();
+        }
+
+        return bookingGuestConnectionQueryService.getConnections(user.getId());
     }
 }

--- a/src/main/java/com/project/cozystay/booking/guest/controller/BookingGuestMeQueryController.java
+++ b/src/main/java/com/project/cozystay/booking/guest/controller/BookingGuestMeQueryController.java
@@ -18,14 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 

--- a/src/main/java/com/project/cozystay/booking/guest/controller/BookingGuestMeQueryController.java
+++ b/src/main/java/com/project/cozystay/booking/guest/controller/BookingGuestMeQueryController.java
@@ -1,6 +1,7 @@
 package com.project.cozystay.booking.guest.controller;
 
 import com.project.cozystay.auth.CustomOAuth2User;
+import com.project.cozystay.booking.dto.BookingResponse;
 import com.project.cozystay.booking.exception.AuthenticationRequiredException;
 import com.project.cozystay.booking.guest.domain.InvitationStatus;
 import com.project.cozystay.booking.guest.dto.BookingGuestConnectionResponse;
@@ -57,5 +58,20 @@ public class BookingGuestMeQueryController {
         }
 
         return bookingGuestConnectionQueryService.getConnections(user.getId());
+    }
+
+    @Operation(
+            summary = "내 동반자 예약 목록 조회",
+            description = "내가 동반자로 초대받고 수락한 예약 목록을 조회합니다."
+    )
+    @GetMapping("/me/bookings")
+    public List<BookingResponse> getMyCompanionBookings(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ){
+        if(user == null){
+            throw new AuthenticationRequiredException();
+        }
+
+        return bookingGuestMeQueryService.getMyCompanionBookings(user.getId());
     }
 }

--- a/src/main/java/com/project/cozystay/booking/guest/domain/BookingGuest.java
+++ b/src/main/java/com/project/cozystay/booking/guest/domain/BookingGuest.java
@@ -39,7 +39,7 @@ public class BookingGuest {
     @Column(name = "guest_email", nullable = false)
     private String guestEmail;
 
-    @Column(name = "guest_phone", nullable = false)
+    @Column(name = "guest_phone")
     private String guestPhone;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/project/cozystay/booking/guest/dto/BookingGuestConnectionResponse.java
+++ b/src/main/java/com/project/cozystay/booking/guest/dto/BookingGuestConnectionResponse.java
@@ -1,0 +1,13 @@
+package com.project.cozystay.booking.guest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BookingGuestConnectionResponse {
+
+    private Long userId;
+    private String NickName;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/project/cozystay/booking/guest/dto/BookingGuestConnectionResponse.java
+++ b/src/main/java/com/project/cozystay/booking/guest/dto/BookingGuestConnectionResponse.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class BookingGuestConnectionResponse {
 
     private Long userId;
-    private String NickName;
+    private String nickName;
     private String profileImageUrl;
 }

--- a/src/main/java/com/project/cozystay/booking/guest/dto/BookingGuestCreateRequest.java
+++ b/src/main/java/com/project/cozystay/booking/guest/dto/BookingGuestCreateRequest.java
@@ -1,6 +1,5 @@
 package com.project.cozystay.booking.guest.dto;
 
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -8,21 +7,7 @@ import lombok.Getter;
 @Getter
 public class BookingGuestCreateRequest {
 
-    private Long guestUserId;
-
-    private String guestName;
-
     @NotBlank(message = "guestEmail은 필수입니다.")
     @Email(message = "guestEmail 형식이 올바르지 않습니다.")
     private String guestEmail;
-
-    @NotBlank(message = "guestPhone은 필수입니다.")
-    private String guestPhone;
-
-    @AssertTrue(message = "guestUserId 또는 guestName 중 하나는 반드시 존재해야 합니다.")
-    public boolean isGuestIdentityValid(){
-        boolean hasUserId = guestUserId != null;
-        boolean hasName = guestName != null && !guestName.isBlank();
-        return hasUserId || hasName;
-    }
 }

--- a/src/main/java/com/project/cozystay/booking/guest/repository/BookingGuestRepository.java
+++ b/src/main/java/com/project/cozystay/booking/guest/repository/BookingGuestRepository.java
@@ -77,4 +77,31 @@ from BookingGuest bg
 where bg.invitationToken = :invitationToken
 """)
     Optional<BookingGuest> findByInvitationTokenForUpdate(@Param("invitationToken") String invitationToken);
+
+    // 내가 예약자로서 초대한 동반자 목록
+    @Query("""
+select bg
+from BookingGuest bg
+join fetch bg.booking b
+where b.guestId = :userId
+and bg.invitationStatus = :status
+""")
+    List<BookingGuest> findGuestsInvitedByMe(
+            @Param("userId") Long userId,
+            @Param("status") InvitationStatus status
+    );
+
+    // 내가 동반자로 초대받은 예약 목록
+    @Query("""
+select bg
+from BookingGuest bg
+join fetch bg.booking b
+where bg.guestUserId = :userId
+and bg.invitationStatus = :status
+""")
+    List<BookingGuest> findInvitationsForMe(
+            @Param("userId") Long userId,
+            @Param("status") InvitationStatus status
+    );
+
 }

--- a/src/main/java/com/project/cozystay/booking/guest/repository/BookingGuestRepository.java
+++ b/src/main/java/com/project/cozystay/booking/guest/repository/BookingGuestRepository.java
@@ -22,6 +22,9 @@ public interface BookingGuestRepository extends JpaRepository<BookingGuest, Long
     // 같은 예약에 같은 이메일 중복 초대 방지
     boolean existsByBooking_IdAndGuestEmail(Long bookingId, String guestEmail);
 
+    // 예약 중복 초대 방지 (회원 ID 기준)
+    boolean existsByBooking_IdAndGuestUserId(Long bookingId, Long guestUserId);
+
     // 게스트 조회
     List<BookingGuest> findAllByBooking_IdOrderByInvitedAtAsc(Long bookingId);
 

--- a/src/main/java/com/project/cozystay/booking/guest/repository/BookingGuestRepository.java
+++ b/src/main/java/com/project/cozystay/booking/guest/repository/BookingGuestRepository.java
@@ -3,7 +3,6 @@ package com.project.cozystay.booking.guest.repository;
 import com.project.cozystay.booking.guest.domain.BookingGuest;
 import com.project.cozystay.booking.guest.domain.InvitationStatus;
 import jakarta.persistence.LockModeType;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/project/cozystay/booking/guest/repository/BookingGuestRepository.java
+++ b/src/main/java/com/project/cozystay/booking/guest/repository/BookingGuestRepository.java
@@ -91,7 +91,7 @@ and bg.invitationStatus = :status
             @Param("status") InvitationStatus status
     );
 
-    // 내가 동반자로 초대받은 예약 목록
+    // 인연 목록 용
     @Query("""
 select bg
 from BookingGuest bg
@@ -100,6 +100,20 @@ where bg.guestUserId = :userId
 and bg.invitationStatus = :status
 """)
     List<BookingGuest> findInvitationsForMe(
+            @Param("userId") Long userId,
+            @Param("status") InvitationStatus status
+    );
+
+    // 동반자 예약 용
+    @Query("""
+select bg
+from BookingGuest bg
+join fetch bg.booking b
+join fetch b.accommodation a
+where bg.guestUserId = :userId
+and bg.invitationStatus = :status
+""")
+    List<BookingGuest> findInvitationsForMeWithBookingAndAccommodation(
             @Param("userId") Long userId,
             @Param("status") InvitationStatus status
     );

--- a/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestCommandService.java
+++ b/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestCommandService.java
@@ -45,8 +45,10 @@ public class BookingGuestCommandService {
             throw new BookingGuestInvitationNotAllowedException("현재 예약 상태에서는 동반자를 초대할 수 없습니다.");
         }
 
+        // 이메일 공백 방지
+        String guestEmail = request.getGuestEmail().trim();
         // 입력받은 이메일로 가입 회원 조회
-        User invitedUser = userRepository.findByEmail(request.getGuestEmail())
+        User invitedUser = userRepository.findByEmail(guestEmail)
                 .orElseThrow(() -> new BookingGuestInvitationNotAllowedException("가입된 회원만 초대할 수 있습니다."));
 
         // 자기 자신 초대 방지
@@ -54,9 +56,9 @@ public class BookingGuestCommandService {
             throw new BookingGuestInvitationNotAllowedException("본인은 초대할 수 없습니다.");
         }
 
-        // 중복 초대 방지 (같은 booking에 같은 이메일)
-        if(bookingGuestRepository.existsByBooking_IdAndGuestEmail(bookingId, request.getGuestEmail())){
-            throw new BookingGuestDuplicateInvitationException("이미 초대된 이메일입니다.");
+        // 중복 초대 방지 (같은 booking에 같은 회원)
+        if(bookingGuestRepository.existsByBooking_IdAndGuestUserId(bookingId, invitedUser.getId())){
+            throw new BookingGuestDuplicateInvitationException("이미 초대된 회원입니다.");
         }
 
         // 인원 제한

--- a/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestCommandService.java
+++ b/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestCommandService.java
@@ -15,14 +15,8 @@ import com.project.cozystay.booking.repository.BookingRepository;
 import com.project.cozystay.user.domain.User;
 import com.project.cozystay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import java.security.SecureRandom;
-import java.time.LocalDateTime;
-import java.util.Base64;
 import java.util.EnumSet;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestCommandService.java
+++ b/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestCommandService.java
@@ -12,6 +12,8 @@ import com.project.cozystay.booking.guest.exception.BookingGuestInvitationNotAll
 import com.project.cozystay.booking.guest.exception.BookingGuestLimitExceededException;
 import com.project.cozystay.booking.guest.repository.BookingGuestRepository;
 import com.project.cozystay.booking.repository.BookingRepository;
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -32,16 +34,7 @@ public class BookingGuestCommandService {
 
     private final BookingRepository bookingRepository;
     private final BookingGuestRepository bookingGuestRepository;
-
-    private final InvitationEmailSender invitationEmailSender;
-
-    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-
-    @Value("${cozystay.mail.invitation-page-url}")
-    private String invitationPageUrl;
-
-    @Value("${cozystay.mail.token-expire-hours:48}")
-    private long tokenExpireHours = 48;
+    private final UserRepository userRepository;
 
     @Transactional
     public BookingGuestCreateResponse invite(Long bookingId, Long inviterUserId, BookingGuestCreateRequest request) {
@@ -53,9 +46,18 @@ public class BookingGuestCommandService {
             throw new BookingGuestInvitationNotAllowedException("예약자 본인만 동반자를 초대할 수 있습니다.");
         }
 
-        // 상태 체크
+        // 예약 상태 체크
         if(NOT_INVITABLE_STATUSES.contains(booking.getStatus())) {
             throw new BookingGuestInvitationNotAllowedException("현재 예약 상태에서는 동반자를 초대할 수 없습니다.");
+        }
+
+        // 입력받은 이메일로 가입 회원 조회
+        User invitedUser = userRepository.findByEmail(request.getGuestEmail())
+                .orElseThrow(() -> new BookingGuestInvitationNotAllowedException("가입된 회원만 초대할 수 있습니다."));
+
+        // 자기 자신 초대 방지
+        if(invitedUser.getId().equals(inviterUserId)){
+            throw new BookingGuestInvitationNotAllowedException("본인은 초대할 수 없습니다.");
         }
 
         // 중복 초대 방지 (같은 booking에 같은 이메일)
@@ -63,7 +65,7 @@ public class BookingGuestCommandService {
             throw new BookingGuestDuplicateInvitationException("이미 초대된 이메일입니다.");
         }
 
-        // 정원 제한
+        // 인원 제한
         // booking.guestCount = 총 인원수, 동반자 최대 = guestCount-1
         int totalGuests = booking.getNumberOfGuests();
         long currentInvited = bookingGuestRepository.countByBooking_IdAndInvitationStatusNot(bookingId, InvitationStatus.DECLINED);
@@ -73,61 +75,20 @@ public class BookingGuestCommandService {
             throw new BookingGuestLimitExceededException("동반자 초대 가능 인원을 초과했습니다.");
         }
 
-        BookingGuest bookingGuest;
-
-        if(request.getGuestUserId() != null) {
-            // 회원 초대
-            bookingGuest = BookingGuest.invite(
-                    booking,
-                    request.getGuestUserId(),
-                    null,
-                    request.getGuestEmail(),
-                    request.getGuestPhone()
-            );
-
-            BookingGuest saved = bookingGuestRepository.save(bookingGuest);
-            return new BookingGuestCreateResponse(
-                    saved.getId(),
-                    saved.getInvitationStatus(),
-                    saved.getInvitedAt());
-        }
-
-        // 비회원 초대
-        if(request.getGuestName() == null || request.getGuestName().isBlank()){
-            throw new BookingGuestInvitationNotAllowedException("비회원 초대 시 이름은 필수입니다.");
-        }
-
-        bookingGuest = BookingGuest.invite(
+        // 회원 초대만 생성
+        BookingGuest bookingGuest = BookingGuest.invite(
                 booking,
-                null, // guestUserId 없음
-                request.getGuestName(),
-                request.getGuestEmail(),
-                request.getGuestPhone()
+                invitedUser.getId(),
+                null,
+                invitedUser.getEmail(),
+                null
         );
 
-        // 비회원만 토큰 발급 + 이메일 발송
-        String token = generateToken();
-        bookingGuest.issueInvitationToken(token, LocalDateTime.now().plusHours(tokenExpireHours));
-
         BookingGuest saved = bookingGuestRepository.save(bookingGuest);
-
-        // 링크 구성 (프론트에서 토큰 받아서 API 호출하도록)
-        String invitationPageLink = UriComponentsBuilder.fromHttpUrl(invitationPageUrl)
-                .pathSegment(token)
-                .toUriString();
-
-
-        invitationEmailSender.send(saved.getGuestEmail(), saved.getGuestName(), invitationPageLink);
 
         return new BookingGuestCreateResponse(
                 saved.getId(),
                 saved.getInvitationStatus(),
                 saved.getInvitedAt());
-    }
-
-    private String generateToken(){
-        byte[] bytes = new byte[32];
-        SECURE_RANDOM.nextBytes(bytes);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 }

--- a/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestConnectionQueryService.java
+++ b/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestConnectionQueryService.java
@@ -1,0 +1,74 @@
+package com.project.cozystay.booking.guest.service;
+
+import com.project.cozystay.booking.guest.domain.BookingGuest;
+import com.project.cozystay.booking.guest.domain.InvitationStatus;
+import com.project.cozystay.booking.guest.dto.BookingGuestConnectionResponse;
+import com.project.cozystay.booking.guest.repository.BookingGuestRepository;
+import com.project.cozystay.user.domain.User;
+import com.project.cozystay.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class BookingGuestConnectionQueryService {
+
+    private final BookingGuestRepository bookingGuestRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<BookingGuestConnectionResponse> getConnections(Long userId){
+
+        // 같은 사람과 여러번 여행했어도 인연 목록에서는 한 번만 보여주기 위해 Map 사용
+        // LinkedHashMap을 사용하면 먼저 추가된 순서가 유지된다.
+        Map<Long, BookingGuestConnectionResponse> connections = new LinkedHashMap<>();
+
+        // 내가 초대한 동반자 중, 초대를 수락한 사람들 조회
+        List<BookingGuest> invitedByMe = bookingGuestRepository.findGuestsInvitedByMe(userId, InvitationStatus.ACCEPTED);
+
+        for(BookingGuest bookingGuest : invitedByMe){
+            Long connectionUserId = bookingGuest.getGuestUserId();
+            addConnection(connections, connectionUserId);
+        }
+
+        // 내가 동반자로 초대받고 수락한 예약 조회
+        List<BookingGuest> invitedMe = bookingGuestRepository.findInvitationsForMe(userId, InvitationStatus.ACCEPTED);
+
+        for(BookingGuest bookingGuest : invitedMe){
+            Long connectionUserId = bookingGuest.getBooking().getGuestId();
+            addConnection(connections, connectionUserId);
+        }
+
+        return List.copyOf(connections.values());
+    }
+
+    private void addConnection(
+            Map<Long, BookingGuestConnectionResponse> connections,
+            Long connectionUserId
+    ){
+        // 비회원 초대 데이터가 남아있거나 이미 추가된 사용자라면 건너뛴다.
+        if(connectionUserId == null || connections.containsKey(connectionUserId)){
+            return;
+        }
+
+        User user = userRepository.findById(connectionUserId).orElse(null);
+
+        if(user == null){
+            return;
+        }
+
+        connections.put(
+                user.getId(),
+                new BookingGuestConnectionResponse(
+                        user.getId(),
+                        user.getNickName(),
+                        user.getProfileImageUrl()
+                )
+        );
+    }
+}

--- a/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestConnectionQueryService.java
+++ b/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestConnectionQueryService.java
@@ -10,9 +10,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -24,51 +26,56 @@ public class BookingGuestConnectionQueryService {
     @Transactional(readOnly = true)
     public List<BookingGuestConnectionResponse> getConnections(Long userId){
 
-        // 같은 사람과 여러번 여행했어도 인연 목록에서는 한 번만 보여주기 위해 Map 사용
-        // LinkedHashMap을 사용하면 먼저 추가된 순서가 유지된다.
-        Map<Long, BookingGuestConnectionResponse> connections = new LinkedHashMap<>();
-
         // 내가 초대한 동반자 중, 초대를 수락한 사람들 조회
-        List<BookingGuest> invitedByMe = bookingGuestRepository.findGuestsInvitedByMe(userId, InvitationStatus.ACCEPTED);
+        List<BookingGuest> invitedByMe = bookingGuestRepository.findGuestsInvitedByMe(
+                userId, InvitationStatus.ACCEPTED
+        );
 
+        List<BookingGuest> invitedMe = bookingGuestRepository.findInvitationsForMe(
+                userId,
+                InvitationStatus.ACCEPTED
+        );
+
+        // 같은 사람과 여러 번 여행했어도 인연 목록에는 한번만 보여주기 위해 Set 사용
+        LinkedHashSet<Long> connectionUserIds = new LinkedHashSet<>();
+
+        // 내가 초대한 동반자 중 초대를 수락한 사람들의 회원 ID 수집
         for(BookingGuest bookingGuest : invitedByMe){
             Long connectionUserId = bookingGuest.getGuestUserId();
-            addConnection(connections, connectionUserId);
+
+            if(connectionUserId != null){
+                connectionUserIds.add(connectionUserId);
+            }
         }
 
-        // 내가 동반자로 초대받고 수락한 예약 조회
-        List<BookingGuest> invitedMe = bookingGuestRepository.findInvitationsForMe(userId, InvitationStatus.ACCEPTED);
-
+        // 내가 동반자로 초대받고 수락한 예약의 예약자 ID 수집
         for(BookingGuest bookingGuest : invitedMe){
             Long connectionUserId = bookingGuest.getBooking().getGuestId();
-            addConnection(connections, connectionUserId);
+
+            if(connectionUserId != null){
+                connectionUserIds.add(connectionUserId);
+            }
         }
 
-        return List.copyOf(connections.values());
-    }
-
-    private void addConnection(
-            Map<Long, BookingGuestConnectionResponse> connections,
-            Long connectionUserId
-    ){
-        // 비회원 초대 데이터가 남아있거나 이미 추가된 사용자라면 건너뛴다.
-        if(connectionUserId == null || connections.containsKey(connectionUserId)){
-            return;
+        if(connectionUserIds.isEmpty()){
+            return List.of();
         }
 
-        User user = userRepository.findById(connectionUserId).orElse(null);
+        // 사용자 정보를 ID 목록 기준으로 한 번에 조회해서 N+1 쿼리를 방지한다.
+        Map<Long, User> usersById = userRepository.findAllById(connectionUserIds)
+                .stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
 
-        if(user == null){
-            return;
-        }
-
-        connections.put(
-                user.getId(),
-                new BookingGuestConnectionResponse(
+        return connectionUserIds.stream()
+                .map(usersById::get)
+                .filter(user -> user != null)
+                .map(user -> new BookingGuestConnectionResponse(
                         user.getId(),
                         user.getNickName(),
                         user.getProfileImageUrl()
-                )
-        );
+                ))
+                .toList();
     }
+
+
 }

--- a/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestMeQueryService.java
+++ b/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestMeQueryService.java
@@ -1,6 +1,7 @@
 package com.project.cozystay.booking.guest.service;
 
 import com.project.cozystay.booking.domain.Booking;
+import com.project.cozystay.booking.dto.BookingResponse;
 import com.project.cozystay.booking.guest.domain.BookingGuest;
 import com.project.cozystay.booking.guest.domain.InvitationStatus;
 import com.project.cozystay.booking.guest.dto.MyInvitationResponse;
@@ -10,6 +11,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -36,5 +39,29 @@ public class BookingGuestMeQueryService {
                     bg.getRespondedAt()
             );
         });
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookingResponse> getMyCompanionBookings(Long userId){
+        List<BookingGuest> bookingGuests = bookingGuestRepository.findInvitationsForMe(
+                userId, InvitationStatus.ACCEPTED
+        );
+
+        return bookingGuests.stream()
+                .map(bookingGuest -> {
+                    Booking booking = bookingGuest.getBooking();
+
+                    return BookingResponse.builder()
+                            .bookingId(booking.getId())
+                            .accommodationId(booking.getAccommodation().getId())
+                            .guestId(booking.getGuestId())
+                            .checkInDate(booking.getCheckInDate())
+                            .checkOutDate(booking.getCheckOutDate())
+                            .numberOfGuests(booking.getNumberOfGuests())
+                            .totalPrice(booking.getTotalPrice())
+                            .bookingStatus(booking.getStatus().name())
+                            .build();
+                })
+                .toList();
     }
 }

--- a/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestMeQueryService.java
+++ b/src/main/java/com/project/cozystay/booking/guest/service/BookingGuestMeQueryService.java
@@ -43,7 +43,7 @@ public class BookingGuestMeQueryService {
 
     @Transactional(readOnly = true)
     public List<BookingResponse> getMyCompanionBookings(Long userId){
-        List<BookingGuest> bookingGuests = bookingGuestRepository.findInvitationsForMe(
+        List<BookingGuest> bookingGuests = bookingGuestRepository.findInvitationsForMeWithBookingAndAccommodation(
                 userId, InvitationStatus.ACCEPTED
         );
 


### PR DESCRIPTION
## 🔗 반영 브랜치

(#68) feat/invitation -> develop

## 📝 작업 내용

### 동반자 초대 로직 수정

- 동반자 초대 요청 DTO를 이메일 기반으로 변경했습니다.
  - 기존 `guestUserId`, `guestName`, `guestPhone` 입력 제거
  - `guestEmail`만 필수 입력으로 사용

- 동반자 초대를 가입 회원 이메일 조회 방식으로 변경했습니다.
  - 입력받은 이메일로 가입 회원을 조회합니다.
  - 가입되지 않은 이메일은 초대할 수 없도록 처리했습니다.
  - 자기 자신 초대를 방지했습니다.
  - 같은 예약에 같은 회원이 중복 초대되지 않도록 회원 ID 기준으로 검사합니다.

- 회원 동반자 초대 시 전화번호 없이 저장 가능하도록 `BookingGuest.guestPhone` nullable 처리를 반영했습니다.

### 인연 목록 조회 API 추가

- 수락된 동반자 관계를 기준으로 내 인연 목록을 조회하는 API를 추가했습니다.
  - 내가 예약자로서 초대한 동반자
  - 내가 동반자로 초대받은 예약의 예약자
  - 중복 사용자는 한 번만 응답되도록 처리

- 인연 목록 응답 DTO를 추가했습니다.
  - `userId`
  - `nickName`
  - `profileImageUrl`

### 동반자로 참여한 예약 목록 조회 API 추가

- 내가 동반자로 초대받고 수락한 예약 목록을 조회하는 API를 추가했습니다.
- 응답은 기존 예약 응답 형식인 `BookingResponse`로 변환해 반환합니다.

## 추가된 API

### 내 인연 목록 조회

```http
GET /api/booking-guests/connections
```
- 수락된 동반자 관계 기준으로 내 인연 목록을 조회합니다. 

### 내가 동반자로 참여한 예약 목록 조회
```http
GET /api/booking-guests/me/bookings
```
- 내가 동반자로 초대받고 수락한 예약 목록을 조회합니다. 

### 주요 변경 파일
- BookingGuestCreateRequest
- BookingGuestCommandService
- BookingGuest
- BookingGuestRepository
- BookingGuestConnectionResponse
- BookingGuestConnectionQueryService
- BookingGuestMeQueryService
- BookingGuestMeQueryController

## 💬 리뷰 요구사항
