### PR TITLE
Fix: 회원가입시 이메일 중복 에러 메시지가 응답되지 않던 버그 해결

### DIFF
--- a/src/main/java/com/project/cozystay/review/service/AccommodationReviewService.java
+++ b/src/main/java/com/project/cozystay/review/service/AccommodationReviewService.java
@@ -49,7 +49,7 @@ public class AccommodationReviewService {
     @Transactional
     public AccommodationReviewResponse createAccommodationReview(Long guestId, AccommodationReviewCreateRequest request) {
         User guest = userRepository.findById(guestId)
-                .orElseThrow(() -> new UserNotFoundException(guestId));
+                .orElseThrow(UserNotFoundException::new);
 
         Booking booking = bookingRepository.findById(request.bookingId())
                 .orElseThrow(() -> new BookingNotFoundException(request.bookingId()));

--- a/src/main/java/com/project/cozystay/review/service/UserReviewService.java
+++ b/src/main/java/com/project/cozystay/review/service/UserReviewService.java
@@ -42,10 +42,10 @@ public class UserReviewService {
         }
 
         User reviewerHost = userRepository.findById(hostId)
-                .orElseThrow(() -> new UserNotFoundException(hostId));
+                .orElseThrow(UserNotFoundException::new);
 
         User targetGuest = userRepository.findById(request.targetGuestId())
-                .orElseThrow(() -> new UserNotFoundException(request.targetGuestId()));
+                .orElseThrow(UserNotFoundException::new);
 
         Booking booking = bookingRepository.findById(request.bookingId())
                 .orElseThrow(() -> new BookingNotFoundException(request.bookingId()));
@@ -81,7 +81,7 @@ public class UserReviewService {
     public List<UserReviewResponse> getUserReviews(Long targetUserId){
 
         if (!userRepository.existsById(targetUserId)) {
-            throw new UserNotFoundException(targetUserId);
+            throw new UserNotFoundException();
         }
 
         List<UserReview> userReviewList = userReviewRepository.findByTargetGuestId(targetUserId);

--- a/src/main/java/com/project/cozystay/user/exception/UserEmailAlreadyExistsException.java
+++ b/src/main/java/com/project/cozystay/user/exception/UserEmailAlreadyExistsException.java
@@ -2,11 +2,7 @@ package com.project.cozystay.user.exception;
 
 public class UserEmailAlreadyExistsException extends RuntimeException {
 
-    public UserEmailAlreadyExistsException(String message) {
-        super(message);
-    }
-
-    public static UserEmailAlreadyExistsException of(String email) {
-        return new UserEmailAlreadyExistsException("이미 존재하는 이메일입니다.");
+    public UserEmailAlreadyExistsException() {
+        super("이미 존재하는 이메일입니다.");
     }
 }

--- a/src/main/java/com/project/cozystay/user/exception/UserEmailAlreadyExistsException.java
+++ b/src/main/java/com/project/cozystay/user/exception/UserEmailAlreadyExistsException.java
@@ -7,6 +7,6 @@ public class UserEmailAlreadyExistsException extends RuntimeException {
     }
 
     public static UserEmailAlreadyExistsException of(String email) {
-        return new UserEmailAlreadyExistsException("이미 존재하는 이메일입니다. email=" + email);
+        return new UserEmailAlreadyExistsException("이미 존재하는 이메일입니다.");
     }
 }

--- a/src/main/java/com/project/cozystay/user/exception/UserNameAlreadyExistsException.java
+++ b/src/main/java/com/project/cozystay/user/exception/UserNameAlreadyExistsException.java
@@ -7,6 +7,6 @@ public class UserNameAlreadyExistsException extends RuntimeException {
     }
 
     public static UserNameAlreadyExistsException of(String username) {
-        return new UserNameAlreadyExistsException("이미 사용 중인 아이디입니다. id=" + username);
+        return new UserNameAlreadyExistsException("이미 사용 중인 아이디입니다.");
     }
 }

--- a/src/main/java/com/project/cozystay/user/exception/UserNameAlreadyExistsException.java
+++ b/src/main/java/com/project/cozystay/user/exception/UserNameAlreadyExistsException.java
@@ -2,11 +2,8 @@ package com.project.cozystay.user.exception;
 
 public class UserNameAlreadyExistsException extends RuntimeException {
 
-    public UserNameAlreadyExistsException(String message) {
-        super(message);
+    public UserNameAlreadyExistsException() {
+        super("이미 사용 중인 아이디입니다.");
     }
 
-    public static UserNameAlreadyExistsException of(String username) {
-        return new UserNameAlreadyExistsException("이미 사용 중인 아이디입니다.");
-    }
 }

--- a/src/main/java/com/project/cozystay/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/project/cozystay/user/exception/UserNotFoundException.java
@@ -2,6 +2,6 @@ package com.project.cozystay.user.exception;
 
 public class UserNotFoundException extends RuntimeException {
     public UserNotFoundException(Long userId) {
-        super("사용자가 존재하지 않습니다. ID: " + userId);
+        super("사용자가 존재하지 않습니다.");
     }
 }

--- a/src/main/java/com/project/cozystay/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/project/cozystay/user/exception/UserNotFoundException.java
@@ -1,7 +1,7 @@
 package com.project.cozystay.user.exception;
 
 public class UserNotFoundException extends RuntimeException {
-    public UserNotFoundException(Long userId) {
+    public UserNotFoundException() {
         super("사용자가 존재하지 않습니다.");
     }
 }

--- a/src/main/java/com/project/cozystay/user/service/EmailService.java
+++ b/src/main/java/com/project/cozystay/user/service/EmailService.java
@@ -1,4 +1,5 @@
 package com.project.cozystay.user.service;
+import com.project.cozystay.user.exception.UserEmailAlreadyExistsException;
 import com.project.cozystay.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -31,7 +32,7 @@ public class EmailService {
     public void sendVerificationEmail(String email) {
 
         if (userRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+            throw UserEmailAlreadyExistsException.of(email);
         }
 
         String code = createRandomCode();

--- a/src/main/java/com/project/cozystay/user/service/EmailService.java
+++ b/src/main/java/com/project/cozystay/user/service/EmailService.java
@@ -32,7 +32,7 @@ public class EmailService {
     public void sendVerificationEmail(String email) {
 
         if (userRepository.existsByEmail(email)) {
-            throw UserEmailAlreadyExistsException.of(email);
+            throw new UserEmailAlreadyExistsException();
         }
 
         String code = createRandomCode();

--- a/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/cozystay/user/service/UserServiceImpl.java
@@ -39,11 +39,11 @@ public class UserServiceImpl implements UserService{
     public void signUp(SignUpRequest signUpRequest) {
 
         if (userRepository.findByUsername(signUpRequest.username()).isPresent()) {
-            throw UserNameAlreadyExistsException.of(signUpRequest.username());
+            throw new UserNameAlreadyExistsException();
         }
 
         if (userRepository.existsByEmail(signUpRequest.email())) {
-            throw UserEmailAlreadyExistsException.of(signUpRequest.email());
+            throw new UserEmailAlreadyExistsException();
         }
 
         User user = User.builder()
@@ -95,7 +95,7 @@ public class UserServiceImpl implements UserService{
     public void existsByUsername(String userName){
 
         if (userRepository.findByUsername(userName).isPresent()) {
-            throw UserNameAlreadyExistsException.of(userName);
+            throw new UserNameAlreadyExistsException();
         }
 
     }


### PR DESCRIPTION
## 🔗 반영 브랜치

(#) refactor/login -> develop

## 📝 작업 내용

1. 이메일 중복시 '이메일 중복 커스텀 에러' 가 정상적으로 오류를 던지지않는 버그 해결
2. 에러 메시지 형식을 간결하게 변경

## 💬 리뷰 요구사항
