### PR TITLE
Refactor : 대표 이미지 수정 API 추가 및 로직 보완

### DIFF
--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -213,5 +213,22 @@ public class AccommodationController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 숙소 대표 이미지 변경
+     */
+    @Operation(summary = "숙소 대표 이미지 변경", description = "숙소의 대표 이미지를 변경합니다.")
+    @PatchMapping("/{accommodationId}/primary-image")
+    public ResponseEntity<AccommodationPrimaryImageResponseDTO> updatePrimaryImage(
+            @PathVariable Long accommodationId,
+            @RequestParam Long imageId,
+            @AuthenticationPrincipal CustomOAuth2User principal
+    ){
+        Long hostId = principal.getId();
+        AccommodationPrimaryImageResponseDTO response =
+                accommodationImageService.updatePrimaryImage(accommodationId, hostId, imageId);
+
+        return ResponseEntity.ok(response);
+    }
+
 }
 

--- a/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/project/cozystay/accommodation/controller/AccommodationController.java
@@ -220,12 +220,12 @@ public class AccommodationController {
     @PatchMapping("/{accommodationId}/primary-image")
     public ResponseEntity<AccommodationPrimaryImageResponseDTO> updatePrimaryImage(
             @PathVariable Long accommodationId,
-            @RequestParam Long imageId,
+            @RequestBody @Valid AccommodationPrimaryImageRequestDTO request,
             @AuthenticationPrincipal CustomOAuth2User principal
     ){
         Long hostId = principal.getId();
         AccommodationPrimaryImageResponseDTO response =
-                accommodationImageService.updatePrimaryImage(accommodationId, hostId, imageId);
+                accommodationImageService.updatePrimaryImage(accommodationId, hostId, request.imageId());
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/project/cozystay/accommodation/domain/AccommodationImage.java
+++ b/src/main/java/com/project/cozystay/accommodation/domain/AccommodationImage.java
@@ -50,6 +50,14 @@ public class AccommodationImage {
 
     public void assignCategory(AccommodationImageCategory category) {this.category = category;}
 
+    public void onPrimary(){
+        this.primary = true;
+    }
+
+    public void unsetPrimary(){
+        this.primary = false;
+    }
+
     public static AccommodationImage create(
             String imageUrl,
             Integer displayOrder,

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationPrimaryImageRequestDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationPrimaryImageRequestDTO.java
@@ -1,0 +1,9 @@
+package com.project.cozystay.accommodation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AccommodationPrimaryImageRequestDTO(
+        @NotNull(message = "이미지 ID는 필수입니다.")
+        Long imageId
+) {
+}

--- a/src/main/java/com/project/cozystay/accommodation/dto/AccommodationPrimaryImageResponseDTO.java
+++ b/src/main/java/com/project/cozystay/accommodation/dto/AccommodationPrimaryImageResponseDTO.java
@@ -1,0 +1,9 @@
+package com.project.cozystay.accommodation.dto;
+
+public record AccommodationPrimaryImageResponseDTO(
+        Long accommodationId,
+        Long beforePrimaryImageId,
+        Long afterPrimaryImageId,
+        String message
+) {
+}

--- a/src/main/java/com/project/cozystay/accommodation/repository/AccommodationImageRepository.java
+++ b/src/main/java/com/project/cozystay/accommodation/repository/AccommodationImageRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AccommodationImageRepository extends JpaRepository <AccommodationImage, Long> {
     @Query("""
@@ -16,4 +17,6 @@ public interface AccommodationImageRepository extends JpaRepository <Accommodati
     List<AccommodationImage> findAllByIdInAndAccommodationId(
             @Param("imageIds") List<Long> imageIds,
             @Param("accommodationId") Long accommodationId);
+
+    Optional<AccommodationImage> findByIdAndAccommodationId(Long imageId, Long accommodationId);
 }

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
@@ -40,11 +40,55 @@ public class AccommodationImageService {
 
         accommodationHostCheck(accommodation, hostId);
 
+        long requestPrimaryCount = request.stream()
+                .filter(dto -> Boolean.TRUE.equals(dto.isPrimary()))
+                .count();
+
+        if (requestPrimaryCount > 1) {
+            throw new IllegalArgumentException("대표 이미지는 하나만 지정할 수 있습니다.");
+        }
+
+        boolean hasRequestPrimary = requestPrimaryCount == 1;
+
+        boolean hasExistingPrimary = accommodation.getImages().stream()
+                .anyMatch(AccommodationImage::isPrimary);
+
+        if (hasRequestPrimary) {
+            accommodation.getImages().forEach(AccommodationImage::unsetPrimary);
+        }
+
+        //대표 이미지가 없을 경우, 대표 이미지를 자동으로 선택
+        int fallbackPrimaryIndex = -1;
+
+        if (!hasRequestPrimary && !hasExistingPrimary) {
+            int minDisplayOrder = Integer.MAX_VALUE;
+
+            for (int i = 0; i < request.size(); i++) {
+                Integer displayOrder = request.get(i).displayOrder();
+
+                if (displayOrder < minDisplayOrder) {
+                    minDisplayOrder = displayOrder;
+                    fallbackPrimaryIndex = i;
+                }
+            }
+        }
+
         List<AccommodationImage> newImages = new ArrayList<>();
         for (int i = 0; i < files.size(); i++) {
             String url = s3Service.uploadFile(files.get(i));
             AccommodationImageRequestDTO dto = request.get(i);
-            AccommodationImage image = AccommodationImage.create(url, dto.displayOrder(), dto.isPrimary());
+
+            boolean isPrimary = Boolean.TRUE.equals(dto.isPrimary());
+
+            if (!hasRequestPrimary && !hasExistingPrimary) {
+                isPrimary = i == fallbackPrimaryIndex;
+            }
+
+            AccommodationImage image = AccommodationImage.create(
+                    url,
+                    dto.displayOrder(),
+                    isPrimary
+            );
 
             if (dto.categoryId() != null) {
                 AccommodationImageCategory category = accommodationImageCategoryRepository

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
@@ -57,8 +57,8 @@ public class AccommodationImageService {
             accommodation.getImages().forEach(AccommodationImage::unsetPrimary);
         }
 
-        //대표 이미지가 없을 경우, 대표 이미지를 자동으로 선택
-        int fallbackPrimaryIndex = -1;
+        //대표 이미지가 없을 경우, 대표 이미지를 자동으로 선택 (기본값은 첫 번째 이미지)
+        int fallbackPrimaryIndex = 0;
 
         if (!hasRequestPrimary && !hasExistingPrimary) {
             int minDisplayOrder = Integer.MAX_VALUE;
@@ -66,7 +66,7 @@ public class AccommodationImageService {
             for (int i = 0; i < request.size(); i++) {
                 Integer displayOrder = request.get(i).displayOrder();
 
-                if (displayOrder < minDisplayOrder) {
+                if (displayOrder != null && displayOrder< minDisplayOrder) {
                     minDisplayOrder = displayOrder;
                     fallbackPrimaryIndex = i;
                 }

--- a/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
+++ b/src/main/java/com/project/cozystay/accommodation/service/AccommodationImageService.java
@@ -133,6 +133,33 @@ public class AccommodationImageService {
         return CategoryWithImagesDTO.fromAccommodation(accommodation);
     }
 
+    @Transactional
+    public AccommodationPrimaryImageResponseDTO updatePrimaryImage(Long accommodationId, Long hostId, Long imageId) {
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 숙소가 없습니다."));
+
+        accommodationHostCheck(accommodation, hostId);
+
+        AccommodationImage targetImage = accommodationImageRepository.findByIdAndAccommodationId(imageId, accommodationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 숙소의 이미지를 찾을 수 없습니다."));
+
+        Long beforePrimaryImageId = accommodation.getImages().stream()
+                .filter(AccommodationImage::isPrimary)
+                .map(AccommodationImage::getId)
+                .findFirst()
+                .orElse(null);
+
+        accommodation.getImages().forEach(AccommodationImage::unsetPrimary);
+        targetImage.onPrimary();
+
+        return new AccommodationPrimaryImageResponseDTO(
+                accommodationId,
+                beforePrimaryImageId,
+                targetImage.getId(),
+                "대표 이미지가 변경되었습니다."
+        );
+    }
+
     private void accommodationHostCheck(Accommodation accommodation, Long hostId) {
         if (!accommodation.getHostId().equals(hostId)) {
             throw new IllegalStateException("숙소의 소유자만 수정할 수 있습니다.");

--- a/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/cozystay/global/exception/GlobalExceptionHandler.java
@@ -108,6 +108,15 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse("서버 내부 오류가 발생했습니다."));
     }
 
+
+    //Todo : IllegalArgumentException 공통 처리 대신 커스텀 예외로 분리
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("BadRequest [IllegalArgumentException]: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleNotReadable(HttpMessageNotReadableException e) {
         log.warn("BadRequest [NotReadable]: {}", e.getMessage());


### PR DESCRIPTION
## 🔗 develop

(#74 ) refactor/accommodationImage -> develop

## 📝 작업 내용

### 1. 숙소 대표 이미지 변경 API 추가

<img width="910" height="223" alt="스크린샷 2026-06-02 191859" src="https://github.com/user-attachments/assets/29b3b485-ce6b-477e-99f7-a5f80c2fc36b" />

### 2. 이미지 추가 시 대표 이미지에 대한 검증 보강
- 기존 숙소에 대표 이미지가 있음 -> 이미지 추가 등록 시 대표 이미지 값이 있다면 해당 이미지로 대체
- 대표 이미지 등록 시, 한 개의 이미지만 등록 가능하도록 보완
- 이미지 등록 시 대표 이미지가 없을 경우, displayOrder(화면 표시 순서)가 가장 낮은 이미지를 대표 이미지로 등록 
- (해당 부분은 우선 디폴트 값을 지정하는 형태로 수정하였지만, 대표 이미지가 없을 시 에러 처리를 해야할지 고민이 필요해 보입니다.)

### 3. IllegalArgumentException 공통 예외 응답 처리 추가

<img width="449" height="114" alt="스크린샷 2026-06-03 171122" src="https://github.com/user-attachments/assets/be12ef55-dd9e-46a0-a14d-4c83b44dc84c" />


## 💬 리뷰 요구사항
- 현재 숙소 비즈니스 로직에서 IllegalArgumentException으로 통일되게 예외 처리를 하고 있습니다. 
- 이에 따라 클라이언트에 명확한 에러 메시지를 전달하기 위해 우선 GlobalExceptionHandelr에 IllegalArgumentException 처리 로직을 등록하였습니다.
- 추후 커스텀 예외처리를 도입하여 예외 타입과 HTTP 상태 코드를 명확하게 분리할 예정입니다.